### PR TITLE
Changes for deployment.

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -20,9 +20,9 @@ For detailed copyright information see the file COPYING in
 the root of the distribution archive.
 """
 
-__revision__ = "$LastChangedRevision$"
+__revision__ = '139'
 __author__ = 'Ero Carrera'
-__version__ = '1.2.10-%d' % int( __revision__[21:-2] )
+__version__ = '1.2.10-%d' % int( __revision__ )
 __contact__ = 'ero.carrera@gmail.com'
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/python
+
+import os
+import sys
 
 try:
     from setuptools import setup
@@ -6,14 +9,19 @@ except ImportError, excp:
     from distutils.core import setup
 
 import pefile
-import os
+
 
 os.environ['COPY_EXTENDED_ATTRIBUTES_DISABLE'] = 'true'
 os.environ['COPYFILE_DISABLE'] = 'true'
 
+# build_msi does not support the 1.2.10-139 versioning schema
+# (or 1.2.10.139), hence the revision number is stripped.
+pefile_version = pefile.__version__
+if 'bdist_msi' in sys.argv:
+    pefile_version, _, _ = pefile_version.partition('-')
 
 setup(name = 'pefile',
-    version = pefile.__version__,
+    version = pefile_version,
     description = 'Python PE parsing module',
     author = pefile.__author__,
     author_email = pefile.__contact__,


### PR DESCRIPTION
Work-around for build_msi issue: https://github.com/erocarrera/pefile/issues/64 and the missing "$LastChangedRevision$" svn macro https://github.com/erocarrera/pefile/issues/65.