### PR TITLE
Fix __pack__()ing a Structure without __unpack__()ing it first.

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -818,9 +818,9 @@ class Structure:
         #self.values = {}
         self.__format_length__ = 0
         self.__field_offsets__ = dict()
+        self.__unpacked_data_elms__ = []
         self.__set_format__(format[1])
         self.__all_zeroes__ = False
-        self.__unpacked_data_elms__ = None
         self.__file_offset__ = file_offset
         if name:
             self.name = name
@@ -866,6 +866,7 @@ class Structure:
             if ',' in elm:
                 elm_type, elm_name = elm.split(',', 1)
                 self.__format__ += elm_type
+                self.__unpacked_data_elms__.append(None)
 
                 elm_names = elm_name.split(',')
                 names = []


### PR DESCRIPTION
Currently, `__pack__()`ing a Structure fails unless it has an `__unpacked_data_elms__` of the correct length, and this field is only initialized in `__unpack__()`.

I think it's desirable to be able to create a Structure (passing it a format), assign all the proper fields, and be able to pack it successfully. That is to say, I do not believe `__unpack__()`ing data into a Structure should be the only valid way to initialize it.

This patch initializes `__unpacked_data_elms__` in `__set_format__()` to a list of Nones of the proper length.

The reason `__unpacked_data_elms__` is kept around is so that Structures with unions may have any one of the union values modified, and the modified value will be the one used when repacking. Perhaps a better solution would be for changing any one of the union values to update the other values immediately, and not keep `__unpacked_data_elms__` at all, but I am uncertain of the best way to implement that.