### PR TITLE
Fix for empty import table

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -3678,7 +3678,7 @@ class PE:
                     'Invalid import data at RVA: 0x%x (%s)' % ( rva, e.value) )
                 break
 
-            if not import_data:
+            if import_data is None:
                 continue
 
 
@@ -3773,7 +3773,7 @@ class PE:
                     'Invalid Import data at RVA: 0x%x (%s)' % ( rva, e.value ) )
                 break
 
-            if not import_data:
+            if import_data is None:
                 continue
 
             dll = self.get_string_at_rva(import_desc.Name)
@@ -3837,6 +3837,8 @@ class PE:
         # bound.
         iat = self.get_import_table(first_thunk, max_length)
 
+        if (len(iat)==0) and (len(ilt)==0):
+            return []
         # OC Patch:
         # Would crash if IAT or ILT had None type
         if (not iat or len(iat)==0) and (not ilt or len(ilt)==0):


### PR DESCRIPTION
PEFILE now properly parses the import table. Previously the import table would return before all imports were processed. Thus, this Closes issue #66

Previously, the file referenced in this issue imports four libraries:
msjet35.dll, KERNEL32.dll, USER32.dll, ADVAPI32.dll. If the IAT and ILT of USER32.dll is empty (both directly point to locations containing 0), pefile will raise a PEFormatError with the text "Invalid Import Table information. Both ILT and IAT appear to be broken."
As a result, USER32.dll is not added to the imports and the imports from ADVAPI32.dll are not even looked into. 

In our studies this also effected additional files and would result with pefile reporting a subsect of the actually import table. 

To fix this behavior, this pull request returns an empty list, if both (the IAT and the ILT) have zero entries, instead of throwing an error or returning None.