### PR TITLE
fix to parse corrupted IAT

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -1037,11 +1037,14 @@ class SectionStructure(Structure):
         else:
             end = offset + self.SizeOfRawData
 
-        # PointerToRawData is not adjusted here as we might want to read any possible extra bytes
-        # that might get cut off by aligning the start (and hence cutting something off the end)
-        #
-        if end > self.PointerToRawData + self.SizeOfRawData:
-            end = self.PointerToRawData + self.SizeOfRawData
+        # FIX for corrupted IAT where data to be read is less than what is expected
+        # because ouside current section.
+        # Examples:
+        # SHA256: 63e23206d243bc38516079372fae014ae98b74489f5862bed3d289d42ba81ba9
+        # SHA256: efc55670c4bdb510b5d0da47c787c54c67d13339d02442bfbd5f8f531e54dc6a
+        pe_last_sect = self.pe.sections[len(self.pe.sections)-1]
+        if end > pe_last_sect.PointerToRawData + pe_last_sect.SizeOfRawData:
+            end = pe_last_sect.PointerToRawData + pe_last_sect.SizeOfRawData
 
         return self.pe.__data__[offset:end]
 


### PR DESCRIPTION
Corrupted IAT cannot be properly parsed by pefile because the data that is read by "get_data" in "SectionStructure" is less than what it should be. My fix allows the method to read all the data that is needed (as length is specified as a input parameter in "get_data" method). 
Fixed code will not read outside the PE data (eg.: will not read appended data, digital signature...).

With following code:
<pre>
pe = pefile.PE('efc55670c4bdb510b5d0da47c787c54c67d13339d02442bfbd5f8f531e54dc6a')
print pe.print_info()
</pre>

You will get following output with current master branch (and IAT will to be parsed/shown):
<pre>
Error parsing the import table. Invalid data at RVA: 0xa150

Error parsing the import table. Invalid data at RVA: 0xa4bc

Error parsing the import directory. Invalid Import data at RVA: 0xa014 (Invalid Import Table information. Both ILT and IAT appear to be broken.)
....
</pre>

With my update IAT will be properly parsed and showed as per below:
<pre>
...
MFC42.DLL Ordinal[5714] (Imported by Ordinal)
MFC42.DLL Ordinal[2982] (Imported by Ordinal)
MFC42.DLL Ordinal[3147] (Imported by Ordinal)
MFC42.DLL Ordinal[3259] (Imported by Ordinal)
MFC42.DLL Ordinal[4465] (Imported by Ordinal)
MFC42.DLL Ordinal[3136] (Imported by Ordinal)
MFC42.DLL Ordinal[3262] (Imported by Ordinal)
MFC42.DLL Ordinal[2985] (Imported by Ordinal)
MFC42.DLL Ordinal[3081] (Imported by Ordinal)
MFC42.DLL Ordinal[2976] (Imported by Ordinal)
MFC42.DLL Ordinal[3830] (Imported by Ordinal)
MFC42.DLL Ordinal[3831] (Imported by Ordinal)
MFC42.DLL Ordinal[3825] (Imported by Ordinal)
...
</pre>
Examples of corrupted files:
SHA256: 63e23206d243bc38516079372fae014ae98b74489f5862bed3d289d42ba81ba9
SHA256: efc55670c4bdb510b5d0da47c787c54c67d13339d02442bfbd5f8f531e54dc6a