### PR TITLE
Fixed issue #93: setup.py should not import pefile.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python
 
+import ast
 import os
+import re
 import sys
 
 try:
@@ -10,10 +12,34 @@ except ImportError as excp:
 
 from unittest import TestLoader, TextTestRunner
 
-import pefile
 
 os.environ['COPY_EXTENDED_ATTRIBUTES_DISABLE'] = 'true'
 os.environ['COPYFILE_DISABLE'] = 'true'
+
+
+def _read_doc():
+    """
+    Parse docstring from file 'pefile.py' and avoid importing
+    this module directly.
+    """
+    with open('pefile.py', 'r') as f:
+        tree = ast.parse(f.read())
+    return ast.get_docstring(tree)
+
+
+def _read_attr(attr_name):
+    """
+    Parse attribute from file 'pefile.py' and avoid importing
+    this module directly.
+
+    __version__, __author__, __contact__,
+    """
+    regex = attr_name + r"\s+=\s+'(.+)'"
+    with open('pefile.py', 'r') as f:
+        match = re.search(regex, f.read())
+    # Second item in the group is the value of attribute.
+    return match.group(1)
+
 
 class TestCommand(Command):
   """Run tests."""
@@ -25,11 +51,13 @@ class TestCommand(Command):
   def finalize_options(self):
     pass
 
+
 # build_msi does not support the 1.2.10-139 versioning schema
 # (or 1.2.10.139), hence the revision number is stripped.
-pefile_version = pefile.__version__
+pefile_version = _read_attr('__version__')
 if 'bdist_msi' in sys.argv:
     pefile_version, _, _ = pefile_version.partition('-')
+
 
 class TestCommand(Command):
   """Run tests."""
@@ -45,11 +73,12 @@ class TestCommand(Command):
     test_suite = TestLoader().discover('./tests', pattern='*_test.py')
     test_results = TextTestRunner(verbosity=2).run(test_suite)
 
+
 setup(name = 'pefile',
     version = pefile_version,
     description = 'Python PE parsing module',
-    author = pefile.__author__,
-    author_email = pefile.__contact__,
+    author = _read_attr('__author__'),
+    author_email = _read_attr('__contact__'),
     url = 'https://github.com/erocarrera/pefile',
     download_url='https://github.com/erocarrera/pefile/tarball/master',
     keywords = ['pe', 'exe', 'dll', 'pefile', 'pecoff'],
@@ -61,7 +90,7 @@ setup(name = 'pefile',
     	'Operating System :: OS Independent',
     	'Programming Language :: Python',
     	'Topic :: Software Development :: Libraries :: Python Modules'],
-    long_description = "\n".join(pefile.__doc__.split('\n')),
+    long_description = "\n".join(_read_doc().split('\n')),
     cmdclass={"test": TestCommand},
     py_modules = ['pefile', 'peutils'],
     packages = ['ordlookup'],


### PR DESCRIPTION
This fixes #93 when future module was not installed automatically as a pefile dependency.

Basically, this fix drops `import pefile` from setup.py.