### PR TITLE
Speedup handling of big strings in get_string_u_at_rva

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -3097,7 +3097,7 @@ class PE(object):
                 versioninfo_string = self.get_string_u_at_rva(ustr_offset)
             else:
                 versioninfo_string = self.get_string_u_at_rva(
-                    ustr_offset, section_end - ustr_offset)
+                    ustr_offset, (section_end - ustr_offset) >> 1)
         except PEFormatError as excp:
             self.__warnings.append(
                 'Error parsing the version information, '


### PR DESCRIPTION
Especially in Samples with invalid strings (no null-terminators) the method get_string_u_at_rva needs really long to process.

This PR speeds up this method, by converting the string to Unicode at once instead of handling each character via for loop.