### PR TITLE
correct bug in get_imphash

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -3622,7 +3622,7 @@ class PE(object):
             return ""
         for entry in self.DIRECTORY_ENTRY_IMPORT:
             libname = entry.dll.lower()
-            parts = libname.rsplit('.', 1)
+            parts = libname.rsplit(b'.', 1)
             if len(parts) > 1 and parts[1] in exts:
                 libname = parts[0]
 

--- a/pefile.py
+++ b/pefile.py
@@ -3640,7 +3640,7 @@ class PE(object):
 
                 impstrs.append('%s.%s' % (libname.lower(),funcname.lower()))
 
-        return md5( ','.join( impstrs ) ).hexdigest()
+        return md5(b','.join(impstrs)).hexdigest()
 
 
     def parse_import_directory(self, rva, size):

--- a/pefile.py
+++ b/pefile.py
@@ -3638,7 +3638,7 @@ class PE(object):
                 if not funcname:
                     continue
 
-                impstrs.append('%s.%s' % (libname.lower(),funcname.lower()))
+                impstrs.append(b'%s.%s' % (libname.lower(),funcname.lower()))
 
         return md5(b','.join(impstrs)).hexdigest()
 


### PR DESCRIPTION
Hi,

I use pefile with python 3.5 and there a bug in the function get_imphash:

for entry in self.DIRECTORY_ENTRY_IMPORT:
            libname = entry.dll.lower()
            parts = libname.rsplit('.', 1)

libname is a byte array and '.' is str so rsplit makes an error: 

File "/usr/local/lib/python3.5/dist-packages/pefile-2016.3.28-py3.5.egg/pefile.py", line 3625, in get_imphash
TypeError: a bytes-like object is required, not 'str'
