### PR TITLE
simple fix for issue #105

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import ast
 import os
 import re
 import sys
+from io import open
 
 try:
     from setuptools import setup, Command
@@ -22,7 +23,7 @@ def _read_doc():
     Parse docstring from file 'pefile.py' and avoid importing
     this module directly.
     """
-    with open('pefile.py', 'r') as f:
+    with open('pefile.py', 'r', encoding='utf-8') as f:
         tree = ast.parse(f.read())
     return ast.get_docstring(tree)
 
@@ -35,7 +36,7 @@ def _read_attr(attr_name):
     __version__, __author__, __contact__,
     """
     regex = attr_name + r"\s+=\s+'(.+)'"
-    with open('pefile.py', 'r') as f:
+    with open('pefile.py', 'r', encoding='utf-8') as f:
         match = re.search(regex, f.read())
     # Second item in the group is the value of attribute.
     return match.group(1)


### PR DESCRIPTION
setup.py should open file with correct encoding to avoid decode error,

this is just a simple fix for https://github.com/erocarrera/pefile/issues/105