### PR TITLE
Replace file() with open() to ensure compatibility with python3

### DIFF
--- a/peutils.py
+++ b/peutils.py
@@ -408,7 +408,7 @@ class SignatureDatabase(object):
                 # Get the data for a file
                 #
                 try:
-                    sig_f = file( filename, 'rt' )
+                    sig_f = open( filename, 'rt' )
                     sig_data = sig_f.read()
                     sig_f.close()
                 except IOError:
@@ -582,6 +582,3 @@ def is_probably_packed( pe ):
         has_significant_amount_of_compressed_data = True
 
     return has_significant_amount_of_compressed_data
-
-
-


### PR DESCRIPTION
file() has been deprecated in python3. Replaced the call with open().

```
  File "/usr/lib/python3.4/site-packages/peutils.py", line 80, in __init__
    self.__load(filename=filename, data=data)
  File "/usr/lib/python3.4/site-packages/peutils.py", line 411, in __load
    sig_f = file( filename, 'rt' )
NameError: name 'file' is not defined
```