### PR TITLE
Remove only unicode character from pefile.py

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -5356,7 +5356,7 @@ class PE(object):
     # [ Microsoft Portable Executable and Common Object File Format Specification ]
     # "The alignment factor (in bytes) that is used to align the raw data of sections in
     #  the image file. The value should be a power of 2 between 512 and 64 K, inclusive.
-    #  The default is 512. If the SectionAlignment is less than the architecture’s page
+    #  The default is 512. If the SectionAlignment is less than the architecture's page
     #  size, then FileAlignment must match SectionAlignment."
     #
     # The following is a hard-coded constant if the Windows loader


### PR DESCRIPTION
A lone unicode character (with a reasonable ascii replacement) is causing setup.py to choke on a machine using cp950. This is another fix for Issue #105. The change at PR #111 is likely a better long term fix, but this PR should also fix the problem as it makes pefile.py pure ascii.

Also seen at [pyinstaller #2019](https://github.com/pyinstaller/pyinstaller/issues/2019)