### PR TITLE
Fix is_driver()

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -5320,11 +5320,12 @@ class PE(object):
         # If it imports from "ntoskrnl.exe" or other kernel components it should
         # be a driver
         #
-        system_DLLs = set(
-            ('ntoskrnl.exe', 'hal.dll', 'ndis.sys', 'bootvid.dll', 'kdcom.dll'))
-        if system_DLLs.intersection(
-                [imp.dll.lower() for imp in self.DIRECTORY_ENTRY_IMPORT]):
-            return True
+        if hasattr(self, 'DIRECTORY_ENTRY_IMPORT'):
+            system_DLLs = set(
+                ('ntoskrnl.exe', 'hal.dll', 'ndis.sys', 'bootvid.dll', 'kdcom.dll'))
+            if system_DLLs.intersection(
+                    [imp.dll.lower() for imp in self.DIRECTORY_ENTRY_IMPORT]):
+                return True
 
         return False
 


### PR DESCRIPTION
Commit f5ff78606528d371714e50db567b92cb2eec31b2 introduced a regression:
Corrupted (truncated) files where no valid import section could
be found would cause an "has no attribute 'DIRECTORY_ENTRY_IMPORT'"
exception to be raised in is_driver().