### PR TITLE
Make get_string_u_at_rva more robust when get_data returns more data than requested

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -4147,7 +4147,7 @@ class PE(object):
 
         s = self.get_section_by_rva(rva)
 
-        if length:
+        if length is not None:
             end = rva + length
         else:
             end = None
@@ -4268,7 +4268,10 @@ class PE(object):
             if null_index == -1:
                 data_length = len(data)
                 if data_length < requested or data_length == max_length:
-                    null_index = len(data) >> 1
+                    null_index = data_length >> 1
+                    break
+                elif data_length < max_length:
+                    null_index = max_length >> 1
                     break
                 else:
                     # Request remaining part of data limited by max_length
@@ -4277,7 +4280,7 @@ class PE(object):
                     requested = max_length
 
             elif null_index % 2 == 0:
-                null_index >>= 1
+                null_index = min(null_index, max_length) >> 1
                 break
 
         # convert selected part of the string to unicode


### PR DESCRIPTION
This commit will make `get_string_u_at_rva` more robust when `get_data` returns more data than requested (happened in my case with sample e55e0a7b5fd1f618e0ed9ea184d2119680dfe155de2b157c712a1b19c8130428)

Also `get_data` will now return 0 bytes, if the requested length is 0.

