### PR TITLE
Fix python2 build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,9 @@ import ast
 import os
 import re
 import sys
-from io import open
+
+if sys.version_info.major == 3:
+    from io import open
 
 try:
     from setuptools import setup, Command
@@ -23,8 +25,12 @@ def _read_doc():
     Parse docstring from file 'pefile.py' and avoid importing
     this module directly.
     """
-    with open('pefile.py', 'r', encoding='utf-8') as f:
-        tree = ast.parse(f.read().encode('ascii', 'backslashreplace'))
+    if sys.version_info.major == 2:
+        with open('pefile.py', 'r') as f:
+            tree = ast.parse(f.read())
+    else:
+        with open('pefile.py', 'r', encoding='utf-8') as f:
+            tree = ast.parse(f.read())
     return ast.get_docstring(tree)
 
 
@@ -36,8 +42,12 @@ def _read_attr(attr_name):
     __version__, __author__, __contact__,
     """
     regex = attr_name + r"\s+=\s+'(.+)'"
-    with open('pefile.py', 'r', encoding='utf-8') as f:
-        match = re.search(regex, f.read())
+    if sys.version_info.major == 2:
+        with open('pefile.py', 'r') as f:
+            match = re.search(regex, f.read())
+    else:
+        with open('pefile.py', 'r', encoding='utf-8') as f:
+            match = re.search(regex, f.read())
     # Second item in the group is the value of attribute.
     return match.group(1)
 


### PR DESCRIPTION
It seems that commit e636f6d9d broke python 2 support, rpmbuild failed with the folliwing error.
This PR fixes this issue ie: we can build both py2 and py3 packages 

+ /usr/bin/python2 setup.py build '--executable=/usr/bin/python2 -s'
Traceback (most recent call last):
  File "setup.py", line 94, in <module>
    long_description = "\n".join(_read_doc().split('\n')),
  File "setup.py", line 27, in _read_doc
    tree = ast.parse(f.read())
  File "/usr/lib64/python2.7/ast.py", line 37, in parse
    return compile(source, filename, mode, PyCF_ONLY_AST)
  File "<unknown>", line 0
SyntaxError: encoding declaration in Unicode string
error: Bad exit status from /var/tmp/rpm-tmp.k5zJA1 (%build)


RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.k5zJA1 (%build)
Could not execute local: Non zero exit
