### PR TITLE
Fixes #130, issues with dump_dict() on some files.

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -966,7 +966,7 @@ class Structure(object):
                         except exceptions.ValueError as e:
                             val = '0x%-8X [INVALID TIME]' % val
                 else:
-                    val = b([b for b in val if b != 0])
+                    val = b([x for x in val if x != 0])
 
                 dump_dict[key] = {'FileOffset': self.__field_offsets__[key] + self.__file_offset__,
                                   'Offset': self.__field_offsets__[key],
@@ -4929,8 +4929,11 @@ class PE(object):
                                     resource_lang_dict.update(resource_lang.data.struct.dump_dict())
                                     resource_id_list.append(resource_lang_dict)
                             if hasattr(resource_id.directory, 'strings') and resource_id.directory.strings:
+                                resource_id_strings_list = list()
                                 for idx, res_string in list(resource_id.directory.strings.items()):
-                                    resource_id_list.append(convert_to_printable(res_string))
+                                    resource_id_strings_list.append(res_string.encode('unicode-escape', 'backslashreplace').decode('ascii'))
+                                if resource_id_strings_list:
+                                    resource_id_list.append({'Strings': resource_id_strings_list})
 
 
         if ( hasattr(self, 'DIRECTORY_ENTRY_TLS') and


### PR DESCRIPTION
Fix a variable scope issue introduced when function named 'b' was created.
Fix resource strings by removing call to a function that no longer exists.
  This fix is more in line with the dump() implementation by using the
  same encode/decode sequence.