### PR TITLE
encoding/parsing error fixes

### DIFF
--- a/ordlookup/__init__.py
+++ b/ordlookup/__init__.py
@@ -1,5 +1,5 @@
-import sys
 from __future__ import absolute_import
+import sys
 from . import ws2_32
 from . import oleaut32
 

--- a/ordlookup/__init__.py
+++ b/ordlookup/__init__.py
@@ -1,3 +1,4 @@
+import sys
 from __future__ import absolute_import
 from . import ws2_32
 from . import oleaut32
@@ -14,8 +15,17 @@ ords = {
     b'oleaut32.dll': oleaut32.ord_names,
 }
 
+PY3 = sys.version_info > (3,)
 
-def ordLookup(libname, ord, make_name=False):
+if PY3:
+    def formatOrdString(ord_val):
+        return 'ord{}'.format(ord_val).encode()
+else:
+    def formatOrdString(ord_val):
+        return b'ord%d' % ord_val
+
+
+def ordLookup(libname, ord_val, make_name=False):
     '''
     Lookup a name for the given ordinal if it's in our
     database.
@@ -23,9 +33,9 @@ def ordLookup(libname, ord, make_name=False):
     names = ords.get(libname.lower())
     if names is None:
         if make_name is True:
-            return b'ord%d' % ord
+            return formatOrdString(ord_val)
         return None
-    name = names.get(ord)
+    name = names.get(ord_val)
     if name is None:
-        return b'ord%d' % ord
+        return formatOrdString(ord_val)
     return name

--- a/pefile.py
+++ b/pefile.py
@@ -45,7 +45,7 @@ import re
 import string
 import array
 import mmap
-from . import ordlookup
+import ordlookup
 
 from collections import Counter
 from hashlib import sha1

--- a/pefile.py
+++ b/pefile.py
@@ -2135,9 +2135,10 @@ class PE(object):
             # The end of the structure is 8 bytes after the start of the Rich
             # string.
             rich_data = self.get_data(0x80, rich_index + 8)
-            if len(rich_data) != 0x80:
+            data = list(struct.unpack(
+                    '<{0}I'.format(int(len(rich_data)/4)), rich_data))
+            if b'RICH' not in data:
                 return None
-            data = list(struct.unpack("<32I", rich_data))
         except PEFormatError:
             return None
 

--- a/pefile.py
+++ b/pefile.py
@@ -3834,8 +3834,12 @@ class PE(object):
             for imp_dll in import_descs:
                 for symbol in imp_dll.imports:
                     for suspicious_symbol in suspicious_imports:
-                        if symbol and symbol.name and symbol.name.startswith(
-                            b(suspicious_symbol)):
+                        if not symbol or not symbol.name:
+                            continue
+                        name = symbol.name
+                        if type(symbol.name) == bytes:
+                            name = symbol.name.decode('utf-8')
+                        if name.startswith(suspicious_symbol):
                             suspicious_imports_count += 1
                             break
                     total_symbols += 1

--- a/pefile.py
+++ b/pefile.py
@@ -3040,7 +3040,12 @@ class PE(object):
                                 string_entry_size = resource_lang.data.struct.Size
                                 string_entry_id = resource_id.id
 
-                                string_entry_data = self.get_data(string_entry_rva, string_entry_size)
+                                # XXX: has been raising exceptions preventing parsing
+                                try:
+                                    string_entry_data = self.get_data(string_entry_rva, string_entry_size)
+                                except:
+                                    continue
+                                
                                 parse_strings( string_entry_data, (int(string_entry_id) - 1) * 16, resource_strings )
                                 strings.update(resource_strings)
 

--- a/pefile.py
+++ b/pefile.py
@@ -45,7 +45,7 @@ import re
 import string
 import array
 import mmap
-import ordlookup
+from . import ordlookup
 
 from collections import Counter
 from hashlib import sha1


### PR DESCRIPTION
We've been using pefile over a very large sample set of binaries (5+ million) and this PR addresses some of the issues that we have run across.

For versioninfo_string we discovered that sometimes that information could not be retrieved which would cause pefile to throw an exception in the subsequent logic.  That fix just skips that logic which doesn't apply when there is no version info.

For the symbol.name fix - sometimes that value would come through as a string and other times it comes through as bytes.  This just checks what the type of symbol.name is and makes sure that it is always a string.