### PR TITLE
added sane behavior when supplying an empty blob as data to pefile.PE

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -1727,8 +1727,8 @@ class PE(object):
 
         self.PE_TYPE = None
 
-        if  not name and not data:
-            return
+        if name is None and data is None:
+            raise ValueError('must either supply name or data')
 
         # This list will keep track of all the structures created.
         # That will allow for an easy iteration through the list
@@ -1781,7 +1781,7 @@ class PE(object):
         through the instance's attributes.
         """
 
-        if fname:
+        if fname is not None:
             stat = os.stat(fname)
             if stat.st_size == 0:
                 raise PEFormatError('The file is empty')
@@ -1804,7 +1804,7 @@ class PE(object):
             finally:
                 if fd is not None:
                     fd.close()
-        elif data:
+        elif data is not None:
             self.__data__ = data
             self.__from_file = False
 

--- a/peutils.py
+++ b/peutils.py
@@ -425,10 +425,10 @@ class SignatureDatabase(object):
 
         # Helper function to parse the signature bytes
         #
-        def to_byte(value) :
-            if '?' in value::
+        def to_byte(value):
+            if '?' in value:
                 return value
-            return int (value, 16)
+            return int(value, 16)
 
 
         # Parse all the signatures in the file


### PR DESCRIPTION
When you call pefile.PE(data=b'') there is no error indicated to the caller.
I added a raise if both name and data are None (pefile is called without arguments).
Also fixed a syntax error in peutils.py