### PR TITLE
Bugfix for integrity check in get_memory_mapped_image()

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -4141,7 +4141,7 @@ class PE(object):
 
             # Miscellaneous integrity tests.
             # Some packer will set these to bogus values to make tools go nuts.
-            if section.Misc_VirtualSize == 0 or section.SizeOfRawData == 0:
+            if section.Misc_VirtualSize == 0 and section.SizeOfRawData == 0:
                 continue
 
             if section.SizeOfRawData > len(self.__data__):


### PR DESCRIPTION
Modified the integrity check in get_memory_mapped_image() to use an and condition instead of an or condition when checking if section.Misc_VirtualSize and section.SizeOfRawData are 0 valued.  The Windows loader will load a sample which has a 0 virtual size and a non-zero raw size.  This fix corrects discrepancies for the memory mapped image provided in pefile, wherein sections which contain a 0 virtual size but non-zero raw size are omitted from the memory mapped image.  As an example, samples 4d39d83e885988240523f2f80b2e75386ed397485bd53b5eaacf93ddf4ea04f4 and 9cae0eedebd0ee501e2af6d71a85191947e2940af5599d6225d762fc18666281 are affected by this fix.