### PR TITLE
Remove past.builtins.old_div

### DIFF
--- a/peutils.py
+++ b/peutils.py
@@ -13,7 +13,6 @@ from __future__ import division
 from future import standard_library
 standard_library.install_aliases()
 from builtins import range
-from past.utils import old_div
 from builtins import object
 
 import os
@@ -578,7 +577,7 @@ def is_probably_packed( pe ):
         if s_entropy > 7.4:
             total_compressed_data += s_length
 
-    if (old_div((1.0 * total_compressed_data),total_pe_data_length)) > .2:
+    if ((1.0 * total_compressed_data)/total_pe_data_length) > .2:
         has_significant_amount_of_compressed_data = True
 
     return has_significant_amount_of_compressed_data


### PR DESCRIPTION
Dear @erocarrera this pull request is about the import of the "past" library. Importing past has bad side-effects for projects that depend on pefile, such as pyinstaller. Using past introduces a dependency on the test module, which in turn depends on other modules... In the end, when freezing a Python program with PyInstaller, this forces many modules to be included for little benefit.

In pefile, there is now just one use of past left, and it looks like using past is not needed since the code needs float division anyway. This pull request removes that use.

Thanks for considering this request!