### PR TITLE
Revert "Use VirtualSize field to zero-pad loaded segments"

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -1001,47 +1001,26 @@ class SectionStructure(Structure):
         Returns bytes() under Python 3.x and set() under 2.7
         """
 
-        # First, we want to figure out what slice of the file will actually get loaded by this section
-        # We want to attempt to provide the zero-padded region that exists between SizeOfRawData and VirtualSize
-
         PointerToRawData_adj = self.pe.adjust_FileAlignment( self.PointerToRawData,
             self.pe.OPTIONAL_HEADER.FileAlignment )
-
-        max_load_size = min(self.SizeOfRawData, self.Misc_VirtualSize, len(self.pe.__data__) - PointerToRawData_adj)
-        padding_size = self.Misc_VirtualSize - max_load_size # bc of above, VirtualSize >= max_load_size
-
         VirtualAddress_adj = self.pe.adjust_SectionAlignment( self.VirtualAddress,
             self.pe.OPTIONAL_HEADER.SectionAlignment, self.pe.OPTIONAL_HEADER.FileAlignment )
-
-        # Next, we want to efficiently slice whatever the user requested out of the file and return it
 
         if start is None:
             offset = PointerToRawData_adj
         else:
             offset = ( start - VirtualAddress_adj ) + PointerToRawData_adj
 
-        # this line is tricky and warrants an explanation
-        # max_load_size is the total size of the section as it would be loaded into memory
-        # We subtract off it the difference between PointerToRawData_adj and offset
-        # which is effectively the number of bytes we're skipping
-        load_size = max_load_size - (PointerToRawData_adj - offset)
-
-        # if we've skipped more than the actual number of bytes that are loaded from the file,
-        # cut into the padding.
-        if load_size < 0:
-            padding_size += load_size
-            load_size = 0
-            if padding_size < 0:
-                padding_size = 0
-
         if length is not None:
-            if length <= load_size:
-                padding_size = 0
-                load_size = length
-            elif length <= load_size + padding_size:
-                padding_size = length - load_size
-
-        return self.pe.__data__[offset:offset+load_size] + b'\0'*padding_size
+            end = offset + length
+        else:
+            end = offset + self.SizeOfRawData
+        # PointerToRawData is not adjusted here as we might want to read any possible extra bytes
+        # that might get cut off by aligning the start (and hence cutting something off the end)
+        #
+        if end > self.PointerToRawData + self.SizeOfRawData:
+            end = self.PointerToRawData + self.SizeOfRawData
+        return self.pe.__data__[offset:end]
 
 
     def __setattr__(self, name, val):
@@ -4180,6 +4159,7 @@ class PE(object):
         will be applied to the image by calling the 'relocate_image()' method. Beware
         that the relocation information is applied permanently.
         """
+
         # Rebase if requested
         #
         if ImageBase is not None:
@@ -4196,11 +4176,15 @@ class PE(object):
 
             # Miscellaneous integrity tests.
             # Some packer will set these to bogus values to make tools go nuts.
-            if section.Misc_VirtualSize == 0:
+            if section.Misc_VirtualSize == 0 or section.SizeOfRawData == 0:
+                continue
+
+            if section.SizeOfRawData > len(self.__data__):
                 continue
 
             if self.adjust_FileAlignment( section.PointerToRawData,
                 self.OPTIONAL_HEADER.FileAlignment ) > len(self.__data__):
+
                 continue
 
             VirtualAddress_adj = self.adjust_SectionAlignment( section.VirtualAddress,
@@ -4216,7 +4200,7 @@ class PE(object):
             elif padding_length<0:
                 mapped_data = mapped_data[:padding_length]
 
-            mapped_data += section.get_data(length=max_virtual_address - VirtualAddress_adj)
+            mapped_data += section.get_data()
 
         # If the image was rebased, restore it to its original form
         #


### PR DESCRIPTION
Reverts erocarrera/pefile#206
The addition looks valuable but it appears to alter the hashes of sections for many (all?) of the files in the regression tests. While I'd expect that behavior in some cases, I need to verify more carefully the effect of the PR.