### PR TITLE
Prevent division by zero when pe.trim() returns no data

### DIFF
--- a/peutils.py
+++ b/peutils.py
@@ -560,6 +560,9 @@ def is_probably_packed( pe ):
     # file. Overlay data won't be taken into account
     #
     total_pe_data_length = len( pe.trim() )
+    # Assume that the file is packed when no data is available
+    if not total_pe_data_length:
+        return True
     has_significant_amount_of_compressed_data = False
 
     # If some of the sections have high entropy and they make for more than 20% of the file's size


### PR DESCRIPTION
```
# skuld-fuzz / 2017-11-11 15:45
# sample: crash-6300cf935e861c36d255567578bf912f:mutate_ff.exe

Traceback (most recent call last):
  File "./skuld-fuzz.py", line 48, in testing_worker
    _ = func(args)
  File "*sanitized*/skuld/targets/pefile_pe.py", line 29, in entry_point
    peutils.is_probably_packed(o)
  File "*sanitized*/lib/python3.6/site-packages/peutils.py", line 577, in is_probably_packed
    if ((1.0 * total_compressed_data)/total_pe_data_length) > .2:
ZeroDivisionError: float division by zero
```