### PR TITLE
Speedup get_section_by_rva, by returing as early as possible

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -4481,10 +4481,9 @@ class PE(object):
     def get_section_by_rva(self, rva):
         """Get the section containing the given address."""
 
-        sections = [s for s in self.sections if s.contains_rva(rva)]
-
-        if sections:
-            return sections[0]
+        for section in self.sections:
+            if section.contains_rva(rva):
+                return section
 
         return None
 


### PR DESCRIPTION
`get_section_by_rva` collects all sections containing the given `rva` but then only returns the first.
If a PE-file has a lot of sections this is very expensive. Returning the first found section for given `rva` does the same, but is faster and needs less memory.