### PR TITLE
Prevent possible IndexError in dump_info

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -4601,7 +4601,7 @@ class PE(object):
                     dump.add_lines(self.VS_FIXEDFILEINFO[idx].dump())
                     dump.add_newline()
 
-                if hasattr(self, 'FileInfo'):
+                if hasattr(self, 'FileInfo') and len(self.FileInfo) > idx:
                     for entry in self.FileInfo[idx]:
                         dump.add_lines(entry.dump())
                         dump.add_newline()


### PR DESCRIPTION
`FileInfo[idx]` might not be set due to errors parsing a PE-file, this prevents `dump_info` from crashing in this case.