### PR TITLE
Enable testing for more recent python3.7 and pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,19 @@
 language: python
-python:
-- '2.7'
-- '3.5'
-- '3.5-dev'
-- '3.6'
-- '3.6-dev'
+cache: pip
+sudo: false
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+      dist: xenial
+      sudo: yes
+    - python: nightly
+      dist: xenial
+      sudo: yes
+    - python: pypy
+    - python: pypy3
 before_install:
 - openssl aes-256-cbc -K $encrypted_a288ee1b388d_key -iv $encrypted_a288ee1b388d_iv
   -in tests/test_data.tar.bz2.enc -out tests/test_data.tar.bz2 -d


### PR DESCRIPTION
Since travis uses slightly outdated python-versions, selecting xenial allows to use more recent python releases.
Also added testing for pip, which should work out of the box.