### PR TITLE
Remove duplicate class TestCommand

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,16 +62,6 @@ class TestCommand(Command):
   def finalize_options(self):
     pass
 
-class TestCommand(Command):
-  """Run tests."""
-  user_options = []
-
-  def initialize_options(self):
-    pass
-
-  def finalize_options(self):
-    pass
-
   def run(self):
     test_suite = TestLoader().discover('./tests', pattern='*_test.py')
     test_results = TextTestRunner(verbosity=2).run(test_suite)

--- a/setup.py
+++ b/setup.py
@@ -53,18 +53,18 @@ def _read_attr(attr_name):
 
 
 class TestCommand(Command):
-  """Run tests."""
-  user_options = []
+    """Run tests."""
+    user_options = []
 
-  def initialize_options(self):
-    pass
+    def initialize_options(self):
+        pass
 
-  def finalize_options(self):
-    pass
+    def finalize_options(self):
+        pass
 
-  def run(self):
-    test_suite = TestLoader().discover('./tests', pattern='*_test.py')
-    test_results = TextTestRunner(verbosity=2).run(test_suite)
+    def run(self):
+        test_suite = TestLoader().discover('./tests', pattern='*_test.py')
+        test_results = TextTestRunner(verbosity=2).run(test_suite)
 
 
 setup(name = 'pefile',


### PR DESCRIPTION
This PR removes duplicated `TestCommand` class in setup.py and adjusts its indentation.