### PR TITLE
Prevent travis PR-builds from failing in before_install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ python:
 - '3.6'
 - '3.6-dev'
 before_install:
-- openssl aes-256-cbc -K $encrypted_a288ee1b388d_key -iv $encrypted_a288ee1b388d_iv
-  -in tests/test_data.tar.bz2.enc -out tests/test_data.tar.bz2 -d
-- tar jxf tests/test_data.tar.bz2 -C tests
+- if test -n "$encrypted_5f282b249fcf_key" && test -n "$encrypted_5f282b249fcf_iv"; then
+    openssl aes-256-cbc -K $encrypted_5f282b249fcf_key -iv $encrypted_5f282b249fcf_iv -in tests/test_data.tar.bz2.enc -out tests/test_data.tar.bz2 -d;
+    tar jxf tests/test_data.tar.bz2 -C tests;
+  fi
 install:
 - pip install -U pip pytest-cov codecov
 - pip install -I -e .


### PR DESCRIPTION
I'm not sure if this change is wanted, since the tests will fail for PRs then in `setup.py test` which depends on several files being decrypted during before_install.
But syntax-errors might be detected by travis even for PRs without decryption key.
