### PR TITLE
Fix: relocate_image() took forever for huge files

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -5729,7 +5729,10 @@ class PE(object):
             raise TypeError('data should be of type: bytes')
 
         if 0 <= offset < len(self.__data__):
-            self.__data__ = ( self.__data__[:offset] + data + self.__data__[offset+len(data):] )
+            if hasattr(self.__data__, "__setitem__"):
+                self.__data__[offset:offset + len(data)] = data
+            else:
+                self.__data__ = ( self.__data__[:offset] + data + self.__data__[offset+len(data):] )
         else:
             return False
 


### PR DESCRIPTION
Current implementation of `PE.set_bytes_at_offset` applies patch by slicing and concatenating `__data__` even if `__data__` object provides `__setitem__` method. This may result in lots of unnecessary copies, even though we're actually working on `mmap` or `bytearray`.

Overhead is particularly visible when using `relocate_image` on huge binary. For `sample.bin` which is 10 MiB in size - rebase operation takes few minutes:
```
$ time python -c "import pefile; pefile.PE('sample.bin').relocate_image(0x400000)"
real    14m38.965s
user    14m33.332s
sys     0m2.754s
```

Implementation provided in this PR uses `__setitem__` method if it's possible. On patched pefile, execution time decreased to several seconds:

```
real    0m19.982s
user    0m17.934s
sys     0m1.980s
```

`sample.bin` MD5: `9045d4dc4885179bb01b484a63c306e3`