### PR TITLE
Fix format typo in Structure.dump()

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -1093,7 +1093,7 @@ class Structure(object):
                     if key.startswith('Signature_'):
                         val_str = '{:8X}'.format(val)
                     else:
-                        val_str = '{#:8X}'.format(val)
+                        val_str = '{:#8X}'.format(val)
 
                     if key == 'TimeDateStamp' or key == 'dwTimeStamp':
                         try:


### PR DESCRIPTION
`'{#:8X}'.format(val)` yields a `KeyError` exception complaining about the #.

Alternate-form # format specifier should come after the colon, so this PR fixes this which seems to be a mere typo.