### PR TITLE
Allow dot in PE symbol name

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -1621,11 +1621,11 @@ def is_valid_dos_filename(s):
 if PY3:
     allowed_function_name = b(
         string.ascii_lowercase + string.ascii_uppercase +
-        string.digits + '_?@$()<>')
+        string.digits + '._?@$()<>')
 else:
     allowed_function_name = b(
         string.lowercase + string.uppercase +
-        string.digits + b'_?@$()<>')
+        string.digits + b'._?@$()<>')
 
 def is_valid_function_name(s):
     return (s is not None and


### PR DESCRIPTION
Hi,

Although it is indeed forbidden as part of function names, the dot character is allowed as part of a symbol name. This happens for instance when building with optimization flags.

I stumbled upon such a case with mingw64's libpython3.7m.dll (compiled as described here: https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-python3/PKGBUILD).

I've uploaded a copy of the resulting library here for your convenience : https://gist.github.com/GabrielGanne/682807a60f8eb537f6a9f2e674c84308

The expected symbol output should be as follow:
``` bash
# python3 ./pefile.py exports libpython3.7m.dll
...
0x6236c960 b'PyErr_CheckSignals' 172
0x62368996 b'PyErr_CheckSignals.part.0' 173 # otherwise all names are None below this point
0x623c0460 b'PyErr_Clear' 174
...

Best regards