### PR TITLE
Recognize two new PE debug types

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -210,7 +210,8 @@ debug_types = [
     ('IMAGE_DEBUG_TYPE_VC_FEATURE',     12),
     ('IMAGE_DEBUG_TYPE_POGO',           13),
     ('IMAGE_DEBUG_TYPE_ILTCG',          14),
-    ('IMAGE_DEBUG_TYPE_MPX',            15) ]
+    ('IMAGE_DEBUG_TYPE_MPX',            15),
+    ('IMAGE_DEBUG_TYPE_REPRO',          16) ]
 
 DEBUG_TYPE = two_way_dict(debug_types)
 

--- a/pefile.py
+++ b/pefile.py
@@ -195,23 +195,24 @@ SECTION_CHARACTERISTICS = two_way_dict(section_characteristics)
 
 
 debug_types = [
-    ('IMAGE_DEBUG_TYPE_UNKNOWN',        0),
-    ('IMAGE_DEBUG_TYPE_COFF',           1),
-    ('IMAGE_DEBUG_TYPE_CODEVIEW',       2),
-    ('IMAGE_DEBUG_TYPE_FPO',            3),
-    ('IMAGE_DEBUG_TYPE_MISC',           4),
-    ('IMAGE_DEBUG_TYPE_EXCEPTION',      5),
-    ('IMAGE_DEBUG_TYPE_FIXUP',          6),
-    ('IMAGE_DEBUG_TYPE_OMAP_TO_SRC',    7),
-    ('IMAGE_DEBUG_TYPE_OMAP_FROM_SRC',  8),
-    ('IMAGE_DEBUG_TYPE_BORLAND',        9),
-    ('IMAGE_DEBUG_TYPE_RESERVED10',     10),
-    ('IMAGE_DEBUG_TYPE_CLSID',          11),
-    ('IMAGE_DEBUG_TYPE_VC_FEATURE',     12),
-    ('IMAGE_DEBUG_TYPE_POGO',           13),
-    ('IMAGE_DEBUG_TYPE_ILTCG',          14),
-    ('IMAGE_DEBUG_TYPE_MPX',            15),
-    ('IMAGE_DEBUG_TYPE_REPRO',          16) ]
+    ('IMAGE_DEBUG_TYPE_UNKNOWN',               0),
+    ('IMAGE_DEBUG_TYPE_COFF',                  1),
+    ('IMAGE_DEBUG_TYPE_CODEVIEW',              2),
+    ('IMAGE_DEBUG_TYPE_FPO',                   3),
+    ('IMAGE_DEBUG_TYPE_MISC',                  4),
+    ('IMAGE_DEBUG_TYPE_EXCEPTION',             5),
+    ('IMAGE_DEBUG_TYPE_FIXUP',                 6),
+    ('IMAGE_DEBUG_TYPE_OMAP_TO_SRC',           7),
+    ('IMAGE_DEBUG_TYPE_OMAP_FROM_SRC',         8),
+    ('IMAGE_DEBUG_TYPE_BORLAND',               9),
+    ('IMAGE_DEBUG_TYPE_RESERVED10',            10),
+    ('IMAGE_DEBUG_TYPE_CLSID',                 11),
+    ('IMAGE_DEBUG_TYPE_VC_FEATURE',            12),
+    ('IMAGE_DEBUG_TYPE_POGO',                  13),
+    ('IMAGE_DEBUG_TYPE_ILTCG',                 14),
+    ('IMAGE_DEBUG_TYPE_MPX',                   15),
+    ('IMAGE_DEBUG_TYPE_REPRO',                 16),
+    ('IMAGE_DEBUG_TYPE_EX_DLLCHARACTERISTICS', 20) ]
 
 DEBUG_TYPE = two_way_dict(debug_types)
 


### PR DESCRIPTION
commit 3f8ffa7181c7c4c5958a55b786bc5eac88289131:

```
Recognize the IMAGE_DEBUG_TYPE_REPRO debug type
The presence of this flag indicates that the PE binary was built with
`/Brepro` by the MSVC linker. See:
```
https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#debug-type

Closes https://github.com/erocarrera/pefile/issues/228

commit d3d26d204d613f483103d6b8cf15e03dcd72ee41:

```
Recognize EX_DLLCHARACTERISTICS debug type
Merely updates the two-way dict, but more work is likely needed to
properly support this.
```

https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#extended-dll-characteristics