### PR TITLE
Fix crash formatting a warning message

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -3672,7 +3672,7 @@ class PE(object):
             if symbol_counts[(symbol_name, symbol_address)] > 10:
                 self.__warnings.append(
                     'Export directory contains more than 10 repeated entries '
-                    '({:s}, 0x{:x}). Assuming corrupt.'.format(
+                    '({}, 0x{:x}). Assuming corrupt.'.format(
                         symbol_name, symbol_address))
                 break
             elif len(symbol_counts) > self.max_symbol_exports:


### PR DESCRIPTION
The warning message for export directories that contain more than 10 repeated entries uses the `{:s}` formatter for a byte value. Under Python 3, this crashes with the error `TypeError: unsupported format string passed to bytes.__format__`.

This commit fixes that crash by removing the `s` formatter. Without specifying that it works under both Python 2 and 3.