### PR TITLE
Ignore device driver extension for imphash

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -3921,7 +3921,7 @@ class PE(object):
 
     def get_imphash(self):
         impstrs = []
-        exts = ['ocx', 'sys', 'dll']
+        exts = ['ocx', 'sys', 'dll', 'drv']
         if not hasattr(self, "DIRECTORY_ENTRY_IMPORT"):
             return ""
         for entry in self.DIRECTORY_ENTRY_IMPORT:


### PR DESCRIPTION
Like when a PE imports GetPrinter out of winspool.drv.