### PR TITLE
Fix f-strings formatting to fix 318

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -3786,8 +3786,8 @@ class PE(object):
             symbol_counts[(symbol_name, symbol_address)] += 1
             if symbol_counts[(symbol_name, symbol_address)] > 10:
                 self.__warnings.append(
-                    f'Export directory contains more than 10 repeated entries '
-                    f'({symbol_name}, {symbol_address:#02x}). Assuming corrupt.')
+                    'Export directory contains more than 10 repeated entries '
+                    '({}, {:02x}). Assuming corrupt.'.format(symbol_name, symbol_address))
                 break
             elif len(symbol_counts) > self.max_symbol_exports:
                 self.__warnings.append(


### PR DESCRIPTION
This fixes the f-strings interpolation at lines 3789 and 3790 which are only compatible in Python 3.6+. Now allows installation and usage for python2.7. 

Tested on Ubuntu 18.04 and 20.04.