### PR TITLE
fixes issue where pefile doesn't identify drivers

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -5740,8 +5740,8 @@ class PE(object):
         # If it imports from "ntoskrnl.exe" or other kernel components it should
         # be a driver
         #
-        system_DLLs = set((b'ntoskrnl.exe', b'hal.dll', b'ndis.sys',
-                           b'bootvid.dll', b'kdcom.dll'))
+        system_DLLs = set(('ntoskrnl.exe', 'hal.dll', 'ndis.sys',
+                           'bootvid.dll', 'kdcom.dll'))
         if system_DLLs.intersection(
                 [imp.dll.decode('utf-8', 'ignore').lower() for imp in self.DIRECTORY_ENTRY_IMPORT]):
             return True


### PR DESCRIPTION
Underlying issue here is between python2 and python3

```bash
Python 2.7.18 (default, Mar  8 2021, 13:02:45)
[GCC 9.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> b'foo'.decode('utf-8', 'ignore').lower() == 'foo'
True
>>> b'foo'.decode('utf-8', 'ignore').lower() == b'foo'
True

Python 3.6.12 (default, Dec 21 2020, 13:42:36)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> b'foo'.decode('utf-8', 'ignore').lower() == 'foo'
True
>>> b'foo'.decode('utf-8', 'ignore').lower() == b'foo'
False
```
Tested against
[corkami driver.sys](https://github.com/viper-framework/pefile-tests/blob/master/tests/corkami/pocs/driver.sys)