### PR TITLE
Include license metadata in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,4 +91,5 @@ setup(name = 'pefile',
     install_requires=[
           'future',
     ],
+    license="MIT",
 )


### PR DESCRIPTION
Having it here simplifies showing this information in pypi, with pip show, or parsing it with tools like pip-licenses.