### PR TITLE
Fix handling of pefile.PE(fast_load=False)

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -2750,7 +2750,7 @@ class PE:
         # The number of imports parsed in this file
         self.__total_import_symbols = 0
 
-        fast_load = fast_load or globals()["fast_load"]
+        fast_load = fast_load if fast_load is not None else globals()["fast_load"]
         try:
             self.__parse__(name, data, fast_load)
         except:


### PR DESCRIPTION
The `fast_load` argument value in `pefile.PE()` constructor needs to be explicitly checked for being `None`. The existing truthy/falsy check means that `fast_load=False` always falls back to the global value (which, when set to `True`, causes a fast load even though user explicitly requested a full load).