### PR TITLE
Fix for 'value' referenced before assignment

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -2759,10 +2759,10 @@ class PE:
 
     def __enter__(self):
         return self
-    
+
     def __exit__(self, type, value, traceback):
         self.close()
-    
+
     def close(self):
         if (
             self.__from_file is True
@@ -3549,6 +3549,7 @@ class PE:
             #
             if directories is None or directory_index in directories:
 
+                value = None
                 if dir_entry.VirtualAddress:
                     if (
                         forwarded_exports_only


### PR DESCRIPTION
We faced this issue while unpacking a pefile:

```
File "/app/venv/lib/python3.6/site-packages/pefile.py", line 2743, in __init__\n    self.__parse__(name, data, fast_load)\n  File "/app/venv/lib/python3.6/site-packages/pefile.py", line 3148, in __parse__\n    self.full_load()\n
File "/app/venv/lib/python3.6/site-packages/pefile.py", line 3259, in full_load\n    self.parse_data_directories()\n
File "/app/venv/lib/python3.6/site-packages/pefile.py", line 3559, in parse_data_directories\n    if value:\nUnboundLocalError: local variable 'value' referenced before assignment\n"
```

If a PEFormatError exception occurs since the value variable is never assigned and will raise an UnboundLocalError exception in the next if clause.