### PR TITLE
accept dot in valid charset for name

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -2279,7 +2279,7 @@ def is_valid_dos_filename(s):
 # charset we will assume the name is invalid.
 
 allowed_function_name = b(
-    string.ascii_lowercase + string.ascii_uppercase + string.digits + "_?@$()<>"
+    string.ascii_lowercase + string.ascii_uppercase + string.digits + "._?@$()<>"
 )
 
 


### PR DESCRIPTION
Optimization may introduce name with .part.NUM or .constprop.NUM. Hence name containing dot must not be rejected.

This is the same pull request #270 but rebased on current master