### PR TITLE
get_overlay_data_start_offset update to not skip offsets larger than filesize

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -7308,7 +7308,8 @@ class PE:
         def update_if_sum_is_larger_and_within_file(
             offset_and_size, file_size=len(self.__data__)
         ):
-            if sum(offset_and_size) > sum(largest_offset_and_size):
+            raw_offset, _ = offset_and_size
+            if raw_offset <= len(self.__data__) and sum(offset_and_size) > sum(largest_offset_and_size):
                 return offset_and_size
             return largest_offset_and_size
 

--- a/pefile.py
+++ b/pefile.py
@@ -7308,9 +7308,7 @@ class PE:
         def update_if_sum_is_larger_and_within_file(
             offset_and_size, file_size=len(self.__data__)
         ):
-            if sum(offset_and_size) <= file_size and sum(offset_and_size) > sum(
-                largest_offset_and_size
-            ):
+            if sum(offset_and_size) > sum(largest_offset_and_size):
                 return offset_and_size
             return largest_offset_and_size
 


### PR DESCRIPTION
… returning result, otherwise if largest offset is more than filesize that will be skipped and some other smaller size_offset will be considered largest_size_offset resulting in wrong overlay offset within data refered to by headers