### PR TITLE
Add Export Hash Method

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -5373,6 +5373,19 @@ class PE:
 
         return md5(",".join(impstrs).encode()).hexdigest()
 
+    def get_exphash(self):
+        if not hasattr(self, 'DIRECTORY_ENTRY_EXPORT'):
+            return ""
+
+        if not hasattr(self.DIRECTORY_ENTRY_EXPORT, 'symbols'):
+            return ""
+
+        export_list = [e.name.decode().lower() for e in self.DIRECTORY_ENTRY_EXPORT.symbols if e]
+        if len(export_list) == 0:
+            return ""
+
+        return sha256(",".join(export_list).encode()).hexdigest()
+
     def parse_import_directory(self, rva, size, dllnames_only=False):
         """Walk and parse the import directory."""
 


### PR DESCRIPTION
Much like an `imphash`, an `exphash` is simply a SHA-256 hash of the exports defined in the Export Address Table. This is helpful for comparing PE files which export functions, which can then be compared to others.

I used SHA-256, but if the maintainers wish to use MD5 to stay inline with the current `get_imphash` method - please leave a comment on this PR.

If no exports are found, an empty string is simply returned. This PR does not modify any other existing functionality within `pefile`.