### PR TITLE
Incorporate PEP 238 and PEP 3120

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
+
 """pefile, Portable Executable reader module
 
 All the PE file basic structures are available with their default names as
@@ -106,7 +106,7 @@ MAX_IMPORT_NAME_LENGTH = 0x200
 MAX_DLL_LENGTH = 0x200
 MAX_SYMBOL_NAME_LENGTH = 0x200
 
-# Lmit maximum number of sections before processing of sections will stop
+# Limit maximum number of sections before processing of sections will stop
 MAX_SECTIONS = 0x800
 
 # The global maximum number of resource entries to parse per file
@@ -2865,8 +2865,8 @@ class PE:
                 # zero) or 15% (if non-zero) of the file's contents. There are
                 # legitimate PEs where 0x00 bytes are close to 50% of the whole
                 # file's contents.
-                if (byte == 0 and 1.0 * byte_count / len(self.__data__) > 0.5) or (
-                    byte != 0 and 1.0 * byte_count / len(self.__data__) > 0.15
+                if (byte == 0 and byte_count / len(self.__data__) > 0.5) or (
+                    byte != 0 and byte_count / len(self.__data__) > 0.15
                 ):
                     self.__warnings.append(
                         (

--- a/peutils.py
+++ b/peutils.py
@@ -1,4 +1,4 @@
-# -*- coding: Latin-1 -*-
+
 """peutils, Portable Executable utilities module
 
 
@@ -579,7 +579,7 @@ def is_probably_packed(pe):
         if s_entropy > 7.4:
             total_compressed_data += s_length
 
-    if ((1.0 * total_compressed_data) / total_pe_data_length) > 0.2:
+    if (total_compressed_data / total_pe_data_length) > 0.2:
         has_significant_amount_of_compressed_data = True
 
     return has_significant_amount_of_compressed_data

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Script to run the tests."""
 
 import sys

--- a/tests/pefile_test.py
+++ b/tests/pefile_test.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 import os
 import difflib
 from hashlib import sha256


### PR DESCRIPTION
PEP 238 – Changing the Division Operator
PEP 3120 – Using UTF-8 as the default source encoding
https://peps.python.org/pep-0238/
https://peps.python.org/pep-3120/
