### PR TITLE
Update new dvrt type and Load Config filed adapt to Windows11

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -7748,6 +7748,41 @@ class PE:
                     and load_config.EnclaveConfigurationPointer
                 ):
                     load_config.EnclaveConfigurationPointer += relocation_difference
+                if (
+                    hasattr(load_config, "VolatileMetadataPointer")
+                    and load_config.VolatileMetadataPointer
+                ):
+                    load_config.VolatileMetadataPointer += relocation_difference
+                if (
+                    hasattr(load_config, "GuardEHContinuationTable")
+                    and load_config.GuardEHContinuationTable
+                ):
+                    load_config.GuardEHContinuationTable += relocation_difference
+                if (
+                    hasattr(load_config, "GuardXFGCheckFunctionPointer")
+                    and load_config.GuardXFGCheckFunctionPointer
+                ):
+                    load_config.GuardXFGCheckFunctionPointer += relocation_difference
+                if (
+                    hasattr(load_config, "GuardXFGDispatchFunctionPointer")
+                    and load_config.GuardXFGDispatchFunctionPointer
+                ):
+                    load_config.GuardXFGDispatchFunctionPointer += relocation_difference
+                if (
+                    hasattr(load_config, "GuardXFGTableDispatchFunctionPointer")
+                    and load_config.GuardXFGTableDispatchFunctionPointer
+                ):
+                    load_config.GuardXFGTableDispatchFunctionPointer += relocation_difference
+                if (
+                    hasattr(load_config, "CastGuardOsDeterminedFailureMode")
+                    and load_config.CastGuardOsDeterminedFailureMode
+                ):
+                    load_config.CastGuardOsDeterminedFailureMode += relocation_difference
+                if (
+                    hasattr(load_config, "GuardMemcpyFunctionPointer")
+                    and load_config.GuardMemcpyFunctionPointer
+                ):
+                    load_config.GuardMemcpyFunctionPointer += relocation_difference
 
     def verify_checksum(self):
 

--- a/pefile.py
+++ b/pefile.py
@@ -2667,17 +2667,17 @@ class PE:
     __IMAGE_INDIR_CONTROL_TRANSFER_DYNAMIC_RELOCATION_format__ = (
         "IMAGE_INDIR_CONTROL_TRANSFER_DYNAMIC_RELOCATION",
         (
-            "I:12,PageRelativeOffset",
-            "I:1,IndirectCall",
-            "I:1,RexWPrefix",
-            "I:1,CfgCheck",
-            "I:1,Reserved",
+            "H:12,PageRelativeOffset",
+            "H:1,IndirectCall",
+            "H:1,RexWPrefix",
+            "H:1,CfgCheck",
+            "H:1,Reserved",
         ),
     )
 
     __IMAGE_SWITCHTABLE_BRANCH_DYNAMIC_RELOCATION_format__ = (
         "IMAGE_SWITCHTABLE_BRANCH_DYNAMIC_RELOCATION",
-        ("I:12,PageRelativeOffset", "I:4,RegisterNumber"),
+        ("H:12,PageRelativeOffset", "H:4,RegisterNumber"),
     )
 
     __IMAGE_TLS_DIRECTORY_format__ = (
@@ -4271,6 +4271,9 @@ class PE:
                     "Overlapping offsets in relocation data "
                     "at RVA: 0x%x" % (reloc_offset + rva)
                 )
+                break
+            if reloc_offset == 0:
+                self.__warnings.append(f"Ignoring zero-padding at file_offset: 0x{file_offset:08x}")
                 break
             offsets.add(reloc_offset)
 

--- a/pefile.py
+++ b/pefile.py
@@ -2774,7 +2774,7 @@ class PE:
             "I,ProcessHeapFlags",
             "I,ProcessAffinityMask",
             "H,CSDVersion",
-            "H,Reserved1",
+            "H,DependentLoadFlags",
             "I,EditList",
             "I,SecurityCookie",
             "I,SEHandlerTable",
@@ -2799,9 +2799,18 @@ class PE:
             "I,DynamicValueRelocTableOffset",
             "H,DynamicValueRelocTableSection",
             "H,Reserved2",
-            "I,GuardRFVerifyStackPointerFunctionPointer" "I,HotPatchTableOffset",
+            "I,GuardRFVerifyStackPointerFunctionPointer",
+            "I,HotPatchTableOffset",
             "I,Reserved3",
             "I,EnclaveConfigurationPointer",
+            "I,VolatileMetadataPointer",
+            "I,GuardEHContinuationTable",
+            "I,GuardEHContinuationCount",
+            "I,GuardXFGCheckFunctionPointer",
+            "I,GuardXFGDispatchFunctionPointer",
+            "I,GuardXFGTableDispatchFunctionPointer",
+            "I,CastGuardOsDeterminedFailureMode",
+            "I,GuardMemcpyFunctionPointer",
         ),
     )
 
@@ -2823,7 +2832,7 @@ class PE:
             "Q,ProcessAffinityMask",
             "I,ProcessHeapFlags",
             "H,CSDVersion",
-            "H,Reserved1",
+            "H,DependentLoadFlags",
             "Q,EditList",
             "Q,SecurityCookie",
             "Q,SEHandlerTable",
@@ -2852,6 +2861,14 @@ class PE:
             "I,HotPatchTableOffset",
             "I,Reserved3",
             "Q,EnclaveConfigurationPointer",
+            "Q,VolatileMetadataPointer",
+            "Q,GuardEHContinuationTable",
+            "Q,GuardEHContinuationCount",
+            "Q,GuardXFGCheckFunctionPointer",
+            "Q,GuardXFGDispatchFunctionPointer",
+            "Q,GuardXFGTableDispatchFunctionPointer",
+            "Q,CastGuardOsDeterminedFailureMode",
+            "Q,GuardMemcpyFunctionPointer",
         ),
     )
 
@@ -4424,9 +4441,6 @@ class PE:
                     "Overlapping offsets in relocation data "
                     "at RVA: 0x%x" % (reloc_offset + rva)
                 )
-                break
-            if reloc_offset == 0:
-                self.__warnings.append(f"Ignoring zero-padding at file_offset: 0x{file_offset:08x}")
                 break
             offsets.add(reloc_offset)
 


### PR DESCRIPTION
https://github.com/erocarrera/pefile/pull/353 is a great pr as it parses the dvrt structure.

However, here is the problem that it didn't deal with.

1. Load Config is still updating when it comes to Windows 11 22H2, so I add some fields copied from winnt.h
2. A mistake at [`18050fe` (#353)](https://github.com/erocarrera/pefile/pull/353/commits/18050fef9e3e3f4f81ab11a9cfd1fd43fe4baabb#diff-101de6bd806e81032cf7f4e9f27d003b2271e5344d049dcc044135a4abb1fbceR2680) missing a comma may cause problems when paring pe32
3. Type mismatch at [`18b71ea` (#353)](https://github.com/erocarrera/pefile/pull/353/commits/18b71eac17866804e79e321c0018fe9d9464c255#diff-101de6bd806e81032cf7f4e9f27d003b2271e5344d049dcc044135a4abb1fbceR2634-R2638) with declaration in winnt.h, which leads to the array half missing

The most important thing is win11 introduces a new dvrt type called `function override` as one part of retpoline. As mentioned in https://github.com/erocarrera/pefile/pull/353, retpoline is the policy that Microsoft use it to mitigate Spectre v2. **In fact, retpoline uses the relocations stored in dvrt and the new type `function override` describes the function needed to be overridden when the image is loading.** Here follows the brief code snippet in winnt.h (WDK ver.10.0.22621.0)

``` c
#define IMAGE_DYNAMIC_RELOCATION_FUNCTION_OVERRIDE              0x00000007

typedef struct _IMAGE_FUNCTION_OVERRIDE_HEADER {
    DWORD FuncOverrideSize;
 // IMAGE_FUNCTION_OVERRIDE_DYNAMIC_RELOCATION  FuncOverrideInfo[ANYSIZE_ARRAY]; // FuncOverrideSize bytes in size
 // IMAGE_BDD_INFO BDDInfo; // BDD region, size in bytes: DVRTEntrySize - sizeof(IMAGE_FUNCTION_OVERRIDE_HEADER) - FuncOverrideSize
} IMAGE_FUNCTION_OVERRIDE_HEADER;
typedef IMAGE_FUNCTION_OVERRIDE_HEADER UNALIGNED * PIMAGE_FUNCTION_OVERRIDE_HEADER;

typedef struct _IMAGE_FUNCTION_OVERRIDE_DYNAMIC_RELOCATION {
    DWORD OriginalRva;          // RVA of original function
    DWORD BDDOffset;            // Offset into the BDD region
    DWORD RvaSize;              // Size in bytes taken by RVAs. Must be multiple of sizeof(DWORD).
    DWORD BaseRelocSize;        // Size in bytes taken by BaseRelocs

    // DWORD RVAs[RvaSize / sizeof(DWORD)];     // Array containing overriding func RVAs. 

    // IMAGE_BASE_RELOCATION  BaseRelocs[ANYSIZE_ARRAY]; // Base relocations (RVA + Size + TO)
                                                         //  Padded with extra TOs for 4B alignment
                                                         // BaseRelocSize size in bytes
} IMAGE_FUNCTION_OVERRIDE_DYNAMIC_RELOCATION;
typedef IMAGE_FUNCTION_OVERRIDE_DYNAMIC_RELOCATION * PIMAGE_FUNCTION_OVERRIDE_DYNAMIC_RELOCATION;

typedef struct _IMAGE_BDD_INFO {
    DWORD         Version;      // decides the semantics of serialized BDD
    DWORD         BDDSize;
    // IMAGE_BDD_DYNAMIC_RELOCATION BDDNodes[ANYSIZE_ARRAY]; // BDDSize size in bytes.
} IMAGE_BDD_INFO;
typedef IMAGE_BDD_INFO * PIMAGE_BDD_INFO;

typedef struct _IMAGE_BDD_DYNAMIC_RELOCATION {
    WORD   Left;                // Index of FALSE edge in BDD array
    WORD   Right;               // Index of TRUE edge in BDD array
    DWORD  Value;               // Either FeatureNumber or Index into RVAs array
} IMAGE_BDD_DYNAMIC_RELOCATION;
typedef IMAGE_BDD_DYNAMIC_RELOCATION * PIMAGE_BDD_DYNAMIC_RELOCATION;

// Function override relocation types in DVRT records.

#define IMAGE_FUNCTION_OVERRIDE_INVALID         0
#define IMAGE_FUNCTION_OVERRIDE_X64_REL32       1  // 32-bit relative address from byte following reloc
#define IMAGE_FUNCTION_OVERRIDE_ARM64_BRANCH26  2  // 26 bit offset << 2 & sign ext. for B & BL
#define IMAGE_FUNCTION_OVERRIDE_ARM64_THUNK     3
```

For more testing, here I give two cases that both are official drivers in win11 which can be downloaded from msdl directly:
1. [dxgkrnl.sys,10.0.22621.580](https://msdl.microsoft.com/download/symbols/dxgkrnl.sys/edc1425f479000/dxgkrnl.sys) 
2. [dxgkrnl.sys,10.0.25127.1000](https://msdl.microsoft.com/download/symbols/dxgkrnl.sys/56c07bdf477000/dxgkrnl.sys)