### PR TITLE
Exphash from sha256 to md5 to match imphash

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -5900,7 +5900,7 @@ class PE:
         if len(export_list) == 0:
             return ""
 
-        return sha256(",".join(export_list).encode()).hexdigest()
+        return md5(",".join(export_list).encode()).hexdigest()
 
     def parse_import_directory(self, rva, size, dllnames_only=False):
         """Walk and parse the import directory."""


### PR DESCRIPTION
PR #354 added exphash using the `sha256` function instead of `md5`, which creates two issues:
- There is a lack of consistency between imphash (which uses md5) and exphash (currently using sha256).
- [The associated YARA implementation (ongoing PR) uses md5](https://github.com/VirusTotal/yara/pull/1795).

This PR proposes using `md5` instead of `sha256` for exphash to maintain consistency.

Note: I believe this confusion stems from a discrepancy between the original blog post about exphash, [which mentions the usage of `sha256`, and its integration into public community projects](https://blog.syscall.party/2023/03/03/introducing-exphash-for-dll-clustering.html).