### PR TITLE
fix PE.get_data

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -6409,10 +6409,10 @@ class PE:
 
         s = self.get_section_by_rva(rva)
 
-        if length:
-            end = rva + length
-        else:
+        if length is None:
             end = None
+        else:
+            end = rva + length
 
         if not s:
             if rva < len(self.header):


### PR DESCRIPTION
Fix a situation when `length` passed to .get_data is 0 - expected results will be an empty  string but currently if rva is outside any section returned data will be unbounded