### PR TITLE
Fix get_memory_mapped_image copy much header data

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -6300,7 +6300,9 @@ class PE:
             if padding_length > 0:
                 mapped_data += b"\0" * padding_length
             elif padding_length < 0:
-                mapped_data = mapped_data[:padding_length]
+                mapped_data = self.header + b"\0" * (
+                    len(mapped_data) + padding_length - len(self.header)
+                )
 
             mapped_data += section.get_data()
 


### PR DESCRIPTION
Before this changing, some non b"\0" data will be copied to the header.  
After this changing, the header will be clear.  