### PR TITLE
fixed a memory leak that caused the pe file to be access locked.

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -29,6 +29,8 @@ import math
 import string
 import mmap
 import uuid
+import gc
+
 
 from collections import Counter
 from typing import Union
@@ -2962,6 +2964,7 @@ class PE:
         ):
             self.__data__.close()
             del self.__data__
+        gc.collect()
 
     def close(self):
         self._close_data()


### PR DESCRIPTION
 this fixes an issue similar to [#356 ](https://github.com/erocarrera/pefile/issues/356) that exists when using with python312 and 311, I didn't test with other versions.
couldn't find where the leak is, so `gc.collect()` from the gc module is used at the end of the  `_close_data()`  function  to clear all unreachable and uncollected memory and release the file access lock.