### PR TITLE
Fix ambiguous string syntax for PEid parsing regexp

### DIFF
--- a/peutils.py
+++ b/peutils.py
@@ -40,7 +40,7 @@ class SignatureDatabase(object):
         # RegExp to match a signature block
         #
         self.parse_sig = re.compile(
-            "\[(.*?)\]\s+?signature\s*=\s*(.*?)(\s+\?\?)*\s*ep_only\s*=\s*(\w+)(?:\s*section_start_only\s*=\s*(\w+)|)",
+            r"\[(.*?)\]\s+?signature\s*=\s*(.*?)(\s+\?\?)*\s*ep_only\s*=\s*(\w+)(?:\s*section_start_only\s*=\s*(\w+)|)",
             re.S,
         )
 


### PR DESCRIPTION
See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1058741