### PR TITLE
Fix cache_adjust_FileAlignment to work with files not aligned to 0x200

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -74,7 +74,7 @@ def lru_cache(maxsize=128, typed=False, copy=False):
 def cache_adjust_FileAlignment(val, file_alignment):
     if file_alignment < FILE_ALIGNMENT_HARDCODED_VALUE:
         return val
-    return (int(val / 0x200)) * 0x200
+    return (int(val / file_alignment)) * file_alignment
 
 
 @lru_cache(maxsize=2048)


### PR DESCRIPTION
Hello,
Please let me know if this isn't a bug, but the library definitely doesn't align PE files aligned to 0x1000 correctly, and this did fix that.

Best regards.
