### PR TITLE
Apply isort to sort all imports

### DIFF
--- a/ordlookup/__init__.py
+++ b/ordlookup/__init__.py
@@ -1,5 +1,4 @@
-from . import ws2_32
-from . import oleaut32
+from . import oleaut32, ws2_32
 
 """
 A small module for keeping a database of ordinal to symbol

--- a/pefile.py
+++ b/pefile.py
@@ -20,27 +20,21 @@ __author__ = "Ero Carrera"
 __version__ = "2023.2.7"
 __contact__ = "ero.carrera@gmail.com"
 
-import collections
-import os
-import struct
 import codecs
-import time
-import math
-import string
-import mmap
-import uuid
-import gc
-
-
-from collections import Counter
-from typing import Union
-from hashlib import sha1
-from hashlib import sha256
-from hashlib import sha512
-from hashlib import md5
-
-import functools
+import collections
 import copy as copymod
+import functools
+import gc
+import math
+import mmap
+import os
+import string
+import struct
+import time
+import uuid
+from collections import Counter
+from hashlib import md5, sha1, sha256, sha512
+from typing import Union
 
 import ordlookup
 

--- a/peutils.py
+++ b/peutils.py
@@ -9,7 +9,10 @@ All rights reserved.
 import os
 import re
 import string
-import urllib.request, urllib.parse, urllib.error
+import urllib.error
+import urllib.parse
+import urllib.request
+
 import pefile
 
 __author__ = "Ero Carrera"

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,8 @@ import os
 import re
 import sys
 
-
 try:
-    from setuptools import setup, Command
+    from setuptools import Command, setup
 except ImportError as excp:
     from distutils.core import setup, Command
 

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from binascii import unhexlify
 import unittest
+from binascii import unhexlify
 
 import pefile
 

--- a/tests/pefile_test.py
+++ b/tests/pefile_test.py
@@ -1,8 +1,8 @@
+import difflib
 import os
 import sys
-import difflib
-from hashlib import sha256
 import unittest
+from hashlib import sha256
 
 import pefile
 


### PR DESCRIPTION
isort sorts imports alphabetically and automatically separates into sections and by type.