### PR TITLE
Increase readability and consistency

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -676,7 +676,6 @@ def parse_strings(data, counter, l):
                 l[counter] = data[i : i + len_ * 2].decode("utf-16le")
             except UnicodeDecodeError:
                 error_count += 1
-                pass
             if error_count >= 3:
                 break
             i += len_ * 2
@@ -1129,16 +1128,16 @@ class Structure:
 class SectionStructure(Structure):
     """Convenience section handling class."""
 
-    def __init__(self, *argl, **argd):
-        if "pe" in argd:
-            self.pe = argd["pe"]
-            del argd["pe"]
+    def __init__(self, *args, **kwargs):
+        if "pe" in kwargs:
+            self.pe = kwargs["pe"]
+            del kwargs["pe"]
 
         self.PointerToRawData = None
         self.VirtualAddress = None
         self.SizeOfRawData = None
         self.Misc_VirtualSize = None
-        Structure.__init__(self, *argl, **argd)
+        Structure.__init__(self, *args, **kwargs)
         self.PointerToRawData_adj = None
         self.VirtualAddress_adj = None
         self.section_min_addr = None
@@ -1523,9 +1522,9 @@ class StructureWithBitfields(Structure):
 class DataContainer:
     """Generic data container."""
 
-    def __init__(self, **args):
+    def __init__(self, **kwargs):
         bare_setattr = super().__setattr__
-        for key, value in args.items():
+        for key, value in kwargs.items():
             bare_setattr(key, value)
 
 
@@ -5620,7 +5619,7 @@ class PE:
 
         # Try to avoid bogus VAs, which are out of the image.
         # This also filters out entries that are zero
-        if begin_of_image <= va and va < end_of_image:
+        if begin_of_image <= va < end_of_image:
             va -= begin_of_image
         return va
 


### PR DESCRIPTION
Remove a superfluous pass statement.
One refactor to a chain comparison operator.
Use args and kwargs throughout.