### PR TITLE
Remove distutils use

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,9 @@ import ast
 import os
 import re
 import sys
-
-try:
-    from setuptools import Command, setup
-except ImportError as excp:
-    from distutils.core import setup, Command
-
 from unittest import TestLoader, TextTestRunner
+
+from setuptools import Command, setup
 
 
 os.environ["COPY_EXTENDED_ATTRIBUTES_DISABLE"] = "true"


### PR DESCRIPTION
setuptools is a better documented and well maintained enhancement based on
distutils. While it provides very similar functionality, it is much better able
to support users on earlier Python releases, and can respond to bug reports
more quickly. A number of platform-specific enhancements already exist in
setuptools that have not been added to distutils, and there is been a
long-standing recommendation in the distutils documentation to prefer
setuptools.
https://peps.python.org/pep-0632