### PR TITLE
Use sha256 for exphash

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -5867,7 +5867,7 @@ class PE:
         if len(export_list) == 0:
             return ""
 
-        return md5(",".join(export_list).encode()).hexdigest()
+        return sha256(",".join(export_list).encode()).hexdigest()
 
     def parse_import_directory(self, rva, size, dllnames_only=False):
         """Walk and parse the import directory."""


### PR DESCRIPTION
Replace md5 by sha256. The asymmetry in imphash (md5) and exphash (sha256) is how they are defined and this choice is external to pefile.