### PR TITLE
Slightly simplify is_exe and is_dll

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -7820,7 +7820,7 @@ class PE:
         if (
             (not self.is_dll())
             and (not self.is_driver())
-            and (EXE_flag & self.FILE_HEADER.Characteristics) == EXE_flag
+            and (EXE_flag & self.FILE_HEADER.Characteristics)
         ):
             return True
 
@@ -7834,7 +7834,7 @@ class PE:
 
         DLL_flag = IMAGE_CHARACTERISTICS["IMAGE_FILE_DLL"]
 
-        if (DLL_flag & self.FILE_HEADER.Characteristics) == DLL_flag:
+        if DLL_flag & self.FILE_HEADER.Characteristics:
             return True
 
         return False


### PR DESCRIPTION
EXE_flag and DLL_flag are powers of two, meaning the equality check after the bitwise And is unnecessary.