### PR TITLE
Fix undeclared next_section_virtual_address usage

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -3650,20 +3650,6 @@ class PE:
             # Set the section's flags according to the Characteristics member
             set_flags(section, section.Characteristics, section_flags)
 
-            if section.__dict__.get(
-                "IMAGE_SCN_MEM_WRITE", False
-            ) and section.__dict__.get("IMAGE_SCN_MEM_EXECUTE", False):
-                if section.Name.rstrip(b"\x00") == b"PAGE" and self.is_driver():
-                    # Drivers can have a PAGE section with those flags set without
-                    # implying that it is malicious
-                    pass
-                else:
-                    self.__warnings.append(
-                        f"Suspicious flags set for section {i}. "
-                        "Both IMAGE_SCN_MEM_WRITE and IMAGE_SCN_MEM_EXECUTE are set. "
-                        "This might indicate a packed executable."
-                    )
-
             self.sections.append(section)
 
         # Sort the sections by their VirtualAddress and add a field to each of them
@@ -3677,6 +3663,21 @@ class PE:
                 section.next_section_virtual_address = self.sections[
                     idx + 1
                 ].VirtualAddress
+
+        for section in self.sections:
+            if section.__dict__.get(
+                "IMAGE_SCN_MEM_WRITE", False
+            ) and section.__dict__.get("IMAGE_SCN_MEM_EXECUTE", False):
+                if section.Name.rstrip(b"\x00") == b"PAGE" and self.is_driver():
+                    # Drivers can have a PAGE section with those flags set without
+                    # implying that it is malicious
+                    pass
+                else:
+                    self.__warnings.append(
+                        f"Suspicious flags set for section {i}. "
+                        "Both IMAGE_SCN_MEM_WRITE and IMAGE_SCN_MEM_EXECUTE are set. "
+                        "This might indicate a packed executable."
+                    )
 
         if self.FILE_HEADER.NumberOfSections > 0 and self.sections:
             return (


### PR DESCRIPTION
The following two files are making pefile crash with the next stacktrace:
[aksdf.sys](https://www.virustotal.com/gui/file/321988427cd33f7195ef419427b17443bdfeeda27d296bd8ce0b495b51de60d8)
[hardlock.sys](https://www.virustotal.com/gui/file/612343b4c6fb91f5fa06cd7622b53005e89bc93746cd99a4325427e617c9a90b)

```python
  File ".../extract.py", line 937, in extract_setup_factory
    pe = pefile.PE(request.file_path, fast_load=True)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../pefile.py", line 2941, in __init__
    self.__parse__(name, data, fast_load)
  File ".../pefile.py", line 3313, in __parse__
    offset = self.parse_sections(sections_offset)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../pefile.py", line 3656, in parse_sections
    if section.Name.rstrip(b"\x00") == b"PAGE" and self.is_driver():
                                                   ^^^^^^^^^^^^^^^^
  File ".../pefile.py", line 7865, in is_driver
    self.parse_data_directories(
  File ".../pefile.py", line 3768, in parse_data_directories
    value = entry[1](dir_entry.VirtualAddress, dir_entry.Size)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../pefile.py", line 5884, in parse_import_directory
    data = self.get_data(rva, image_import_descriptor_size)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../pefile.py", line 6370, in get_data
    s = self.get_section_by_rva(rva)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../pefile.py", line 6538, in get_section_by_rva
    if section.contains_rva(rva):
       ^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../pefile.py", line 1285, in contains_rva
    self.next_section_virtual_address is not None
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'SectionStructure' object has no attribute 'next_section_virtual_address'
```

From my understanding, the `parse_sections` function may end up calling `self.is_driver()` as it's parsing the sections, but before the `parse_sections` function goes over the newly parsed sections to configure the `next_section_virtual_address` variable. Since `is_driver()` ends up relying on it, it is crashing.

I believe the code that needs the `is_driver()` call is only adding warnings, so it would not cause any functional change to put it after the code assigning the value to `next_section_virtual_address`.