### PR TITLE
Remove mode paramter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def _read_doc():
     Parse docstring from file 'pefile.py' and avoid importing
     this module directly.
     """
-    with open("pefile.py", "r", encoding="utf-8") as f:
+    with open("pefile.py", encoding="utf-8") as f:
         tree = ast.parse(f.read())
     return ast.get_docstring(tree)
 
@@ -31,7 +31,7 @@ def _read_attr(attr_name):
     __version__, __author__, __contact__,
     """
     regex = attr_name + r"\s+=\s+['\"](.+)['\"]"
-    with open("pefile.py", "r", encoding="utf-8") as f:
+    with open("pefile.py", encoding="utf-8") as f:
         match = re.search(regex, f.read())
     # Second item in the group is the value of attribute.
     return match.group(1)


### PR DESCRIPTION
The mode parameter of the open function defaults to 'r', open for reading, so does not need to be specified.