### PR TITLE
Non-functional change in parse_rich_header

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -3373,7 +3373,6 @@ class PE:
         """
 
         # Rich Header constants
-        #
         DANS = 0x536E6144  # 'DanS' as dword
         RICH = 0x68636952  # 'Rich' as dword
 
@@ -3417,7 +3416,7 @@ class PE:
         checksum = int.from_bytes(key, "little")
         # the checksum should be present 3 times after the DanS signature
         if (
-            data[0] ^ checksum != DANS
+            data[0] != DANS ^ checksum
             or data[1] != checksum
             or data[2] != checksum
             or data[3] != checksum
@@ -3433,16 +3432,13 @@ class PE:
         data = data[4:]
         for i in range(len(data) // 2):
             # Stop until the Rich footer signature is found
-            #
             if data[2 * i] == RICH:
                 # it should be followed by the checksum
-                #
                 if data[2 * i + 1] != checksum:
                     self.__warnings.append("Rich Header is malformed")
                 break
 
             # header values come by pairs
-            #
             headervalues += [data[2 * i] ^ checksum, data[2 * i + 1] ^ checksum]
         return result
 


### PR DESCRIPTION
Change rich header check to be more logical in checking the DanS bytes; functionally equivalent.