### PR TITLE
Fix bug with not returning all OPTIONAL_HEADER DataDirectory entries

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -3267,7 +3267,7 @@ class PE:
             )
 
         MAX_ASSUMED_VALID_NUMBER_OF_RVA_AND_SIZES = 0x100
-        for i in range(int(0x7FFFFFFF & self.OPTIONAL_HEADER.NumberOfRvaAndSizes)):
+        for i in range(16):
             if len(self.__data__) - offset == 0:
                 break
 


### PR DESCRIPTION
Currently an assumption is made that the number of address/size pairs in the OPTIONAL_HEADER DataDirectory array is given by OPTIONAL_HEADER.NumberOfRvaAndSizes. From the looks of it, most implementations I've found just have a fixed size of 16 (see references below where this quirk seems to be "documented"). From how it seems to be getting used in practice for various PE files that don't set it to 16, NumberOfRvaAndSizes seems to be getting treated as count of how many of the pointers in the DataDirectory list are "null" (zero address and zero size) -- which is kinda obnoxious since it goes against what several of the Microsoft documentation pages say about using it to avoid probing too far.

This issue is the underlying cause of a bug report I got, https://github.com/LLNL/Surfactant/issues/295, and is related to https://github.com/erocarrera/pefile/issues/264.

I can't share the actual file, but I've attached a screenshot from XPEViewer showing how the first entries are 0's for their address/size, and its only index 6 and onward that are actually set. If you can find a bootable UEFI kernel image, I think that would likely exhibit similar behavior. The NumberOfRvaAndSizes for this file is 6.

Before the changes in this PR, this is what pefile shows when I print OPTIONAL_HEADER.DATA_DIRECTORY, and you can see that only the first 6 (empty) entries are in the list (everything else is inaccessible...):
```shell
[<Structure: [IMAGE_DIRECTORY_ENTRY_EXPORT] 0xC8 0x0 VirtualAddress: 0x0 0xCC 0x4 Size: 0x0>,
<Structure: [IMAGE_DIRECTORY_ENTRY_IMPORT] 0xD0 0x0 VirtualAddress: 0x0 0xD4 0x4 Size: 0x0>,
<Structure: [IMAGE_DIRECTORY_ENTRY_RESOURCE] 0xD8 0x0 VirtualAddress: 0x0 0xDC 0x4 Size: 0x0>,
<Structure: [IMAGE_DIRECTORY_ENTRY_EXCEPTION] 0xE0 0x0 VirtualAddress: 0x0 0xE4 0x4 Size: 0x0>,
<Structure: [IMAGE_DIRECTORY_ENTRY_SECURITY] 0xE8 0x0 VirtualAddress: 0x0 0xEC 0x4 Size: 0x0>,
<Structure: [IMAGE_DIRECTORY_ENTRY_BASERELOC] 0xF0 0x0 VirtualAddress: 0x0 0xF4 0x4 Size: 0x0>]
```

After the changes in this PR, this is what pefile shows when I print OPTIONAL_HEADER.DATA_DIRECTORY, which matches what XPEViewer shows for the addresses and sizes of the data directory entries:
```shell
[<Structure: [IMAGE_DIRECTORY_ENTRY_EXPORT] 0xC8 0x0 VirtualAddress: 0x0 0xCC 0x4 Size: 0x0>,
<Structure: [IMAGE_DIRECTORY_ENTRY_IMPORT] 0xD0 0x0 VirtualAddress: 0x0 0xD4 0x4 Size: 0x0>,
<Structure: [IMAGE_DIRECTORY_ENTRY_RESOURCE] 0xD8 0x0 VirtualAddress: 0x0 0xDC 0x4 Size: 0x0>,
<Structure: [IMAGE_DIRECTORY_ENTRY_EXCEPTION] 0xE0 0x0 VirtualAddress: 0x0 0xE4 0x4 Size: 0x0>,
<Structure: [IMAGE_DIRECTORY_ENTRY_SECURITY] 0xE8 0x0 VirtualAddress: 0x0 0xEC 0x4 Size: 0x0>,
<Structure: [IMAGE_DIRECTORY_ENTRY_BASERELOC] 0xF0 0x0 VirtualAddress: 0x0 0xF4 0x4 Size: 0x0>,
<Structure: [IMAGE_DIRECTORY_ENTRY_DEBUG] 0xF8 0x0 VirtualAddress: 0x7865742E 0xFC 0x4 Size: 0x74>,
<Structure: [IMAGE_DIRECTORY_ENTRY_COPYRIGHT] 0x100 0x0 VirtualAddress: 0xAD4000 0x104 0x4 Size: 0x1000>,
<Structure: [IMAGE_DIRECTORY_ENTRY_GLOBALPTR] 0x108 0x0 VirtualAddress: 0xAD4000 0x10C 0x4 Size: 0x1000>,
<Structure: [IMAGE_DIRECTORY_ENTRY_TLS] 0x110 0x0 VirtualAddress: 0x0 0x114 0x4 Size: 0x0>,
<Structure: [IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG] 0x118 0x0 VirtualAddress: 0x0 0x11C 0x4 Size: 0x60000020>,
<Structure: [IMAGE_DIRECTORY_ENTRY_BOUND_IMPORT] 0x120 0x0 VirtualAddress: 0x7461642E 0x124 0x4 Size: 0x61>,
<Structure: [IMAGE_DIRECTORY_ENTRY_IAT] 0x128 0x0 VirtualAddress: 0x21E000 0x12C 0x4 Size: 0xAD5000>,
<Structure: [IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT] 0x130 0x0 VirtualAddress: 0x1C6200 0x134 0x4 Size: 0xAD5000>,
<Structure: [IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR] 0x138 0x0 VirtualAddress: 0x0 0x13C 0x4 Size: 0x0>,
<Structure: [IMAGE_DIRECTORY_ENTRY_RESERVED] 0x140 0x0 VirtualAddress: 0x0 0x144 0x4 Size: 0xC0000040>]
```

![image](https://github.com/user-attachments/assets/a20e76e6-bf63-4661-8e49-94178391bfc9)

References for DataDirectory having a fixed size of 16:
* [Google Drive link in README for PE Format Layout](https://drive.google.com/file/d/0B3_wGJkuWLytbnIxY1J5WUs4MEk/view?resourcekey=0-n5zZ2UW39xVTH8ZSu6C2aQ) -- low resolution is hard to read, but squint and you can make out `_IMAGE_DATA_DIRECTORY DataDirectory[16];` in the box for the optional header layout
* [An In-Depth Look into the Win32 Portable Executable File Format link from pefile README](https://docs.microsoft.com/en-us/archive/msdn-magazine/2002/february/inside-windows-win32-portable-executable-file-format-in-detail) -- "The DataDirectory is an array of 16 structures."
* [Windows 10 SDK #define setting the value to 16](https://github.com/tpn/winsdk-10/blob/9b69f/Include/10.0.10240.0/km/ntimage.h#L253)
* [winnt.h header file](https://codemachine.com/downloads/win80/winnt.h) -- IMAGE_NUMBEROF_DIRECTORY_ENTRIES is set to 16, and then used as the size for defining DataDirectory
* [MinGW implementation of winnt.h](https://github.com/Alexpux/mingw-w64/blob/master/mingw-w64-tools/widl/include/winnt.h) -- does the same as the above two
* [WINE implementation of winnt.h](https://github.com/wine-mirror/wine/blob/master/include/winnt.h) -- same as the above headers