### PR TITLE
Wiki docs updates

### DIFF
--- a/PEiDSignatures.md
+++ b/PEiDSignatures.md
@@ -10,7 +10,7 @@ http:/<span></span>/woodmann.com/BobSoft/Files/Other/UserDB.zip (dead link, albe
 
 First import the new module, _peutils_, included with _pefile_
 
-```
+```python
 import peutils
 ```
 
@@ -18,19 +18,19 @@ Then we need to load a signature database, we can do this in different ways.
 
   * Loading a database from a file in the local filesystem
 
-```
+```python
 signatures = peutils.SignatureDatabase('/path/to/signature.txt')
 ```
 
   * Loading a database directly from a URL
 
-```
+```python
 signatures = peutils.SignatureDatabase('http://url.to/signature/file.txt')
 ```
 
   * And finally, directly from data (for instance, if we have already read and loaded the contents of a database)
 
-```
+```python
 with file('/path/to/signature/file.txt', 'rt') as f: 
     sig_data = f.read()
 signatures = peutils.SignatureDatabase(data=sig_data)
@@ -38,7 +38,7 @@ signatures = peutils.SignatureDatabase(data=sig_data)
 
 It's also possible to aggregate more signatures to an already created instance by just using the _load()_ method:
 
-```
+```python
 signatures.load('/Users/ero/Devel/pefile/userdb-extra.txt')
 ```
 
@@ -47,7 +47,7 @@ signatures.load('/Users/ero/Devel/pefile/userdb-extra.txt')
 
 Once we have a _SignatureDatabase_ instance, we can run PE instances through it in order to find matching packer signatures:
 
-```
+```python
 matches = signatures.match(pe, ep_only = True)
 ```
 
@@ -61,7 +61,7 @@ matches = signatures.match(pe, ep_only = True)
 
 We can also get all possible matches found as the signature tree is walked. The last signature will always be the most precise (as more bytes will have been matched) and is the one returned by the _match()_ method.
 
-```
+```python
 matches = sig.match_all(pe, ep_only = True)
 ```
 
@@ -79,7 +79,7 @@ Experimental and not specially intelligent when generating signatures, _peutils_
 
 One can generate signatures for the entry point of a PE file as follows:
 
-```
+```python
 signatures.generate_ep_signature(pe, 'Name of the signature', length_of_the_signature)
 ```
 
@@ -87,7 +87,7 @@ signatures.generate_ep_signature(pe, 'Name of the signature', length_of_the_sign
 Alternatively signatures for all section in a PE file can be generated as follows:
 
 
-```
+```python
 signatures.generate_section_signatures(pe, 'Name of the signature', length_of_the_signature)
 ```
 

--- a/ReadingResourceStrings.md
+++ b/ReadingResourceStrings.md
@@ -35,8 +35,8 @@ Hence, to extract those string from the file, we can write a small Python script
 
 First we need to read the directory entry for the resources and see if there's an entry of type RT\_STRING (value 6).
 
-```
-print [entry.id for entry in pe.DIRECTORY_ENTRY_RESOURCE.entries]
+```python
+print([entry.id for entry in pe.DIRECTORY_ENTRY_RESOURCE.entries])
 ```
 
 Would produce something like `(3, 4, 5, 6, 9, 14, 24)`. Therefore we know that in this specific PE file the RT\_STRING directory entry is at index 3.
@@ -82,7 +82,7 @@ We can iterate through the entries with the following code:
 
 (the strings will be saved in the _strings_ list)
 
-```
+```python
 # The List will contain all the extracted Unicode strings
 #
 strings = list()
@@ -130,5 +130,5 @@ for entry in rt_string_directory.directory.entries:
     ustr = pe.get_string_u_at_rva(data_rva+offset, max_length=ustr_length)
     offset += ustr_length*2
     strings.append(ustr)
-    print 'String of length', ustr_length, 'at offset', offset
+    print('String of length', ustr_length, 'at offset', offset)
 ```

--- a/UsageExamples.md
+++ b/UsageExamples.md
@@ -8,14 +8,14 @@ Import the module and parse a file.
 
 ```python
 import pefile
-pe =  pefile.PE(‘/path/to/pefile.exe’)
+pe =  pefile.PE('/path/to/pefile.exe')
 ```
 
 Optionally, setting the _fast\_load_ argument to _True_ will prevent parsing the directories. In large PE files this can make loading significantly faster and it might be a good idea to use it none of the information from the data directories is needed.
 
 ```python
 import pefile
-pe = pefile.PE(‘/path/to/pefile.exe’, fast_load=True)
+pe = pefile.PE('/path/to/pefile.exe', fast_load=True)
 ```
 
 A later call to the _full\_load()_ method would parse the missing information.


### PR DESCRIPTION
code block updates
remove smart quotes

these pages are still linked in the readme. there is a fork that published pefile.readthedocs.io, but that looks to be behind.
I haven't looked if they submitted a PR

[NO_TRAIN]::