### PR TITLE
Fix: remove redundant two_way_dict() call on Sublanguage definitions

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -645,7 +645,6 @@ sublang = [
     ("SUBLANG_GAELIC_MANX", 0x03),
 ]
 
-SUBLANG = two_way_dict(sublang)
 
 # Initialize the dictionary with all the name->value pairs
 SUBLANG = dict(sublang)


### PR DESCRIPTION
```
for sublang_name, sublang_value in sublang:
    if sublang_value in SUBLANG:
        SUBLANG[sublang_value].append(sublang_name)
    else:
        SUBLANG[sublang_value] = [sublang_name]

```
already handles the two_way_dict creation with duplicate handling, No need for the two_way_dict() call above that