### PR TITLE
Broaden definition of a pageable section

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -7886,9 +7886,8 @@ class PE:
         ):
             return True
 
-        driver_like_section_names = {b"page", b"paged"}
-        if driver_like_section_names.intersection(
-            {section.Name.lower().rstrip(b"\x00") for section in self.sections}
+        if any(
+            {section.Name.lower().startswith(b"page") for section in self.sections}
         ) and (
             self.OPTIONAL_HEADER.Subsystem
             in (


### PR DESCRIPTION
A driver developer has the option to make designated parts of a driver
pageable so that Windows can move these parts to the paging file when
they are not in use. To make a code or data section pageable, the driver
developer assigns a name that begins with "PAGE" to the section. The I/O
manager checks the names of the sections when it loads a driver. If a
section name begins with "PAGE", the I/O manager makes the section
pageable.
https://learn.microsoft.com/en-us/windows-hardware/drivers/kernel/making-drivers-pageable