### PR TITLE
fix: respect VirtualSize when building the memory-mapped image (#392)

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -6325,7 +6325,19 @@ class PE:
             elif padding_length < 0:
                 mapped_data = mapped_data[:padding_length]
 
-            mapped_data += section.get_data()
+            section_data = section.get_data()
+            virtual_size = section.Misc_VirtualSize
+            if virtual_size and len(section_data) != virtual_size:
+                # Only Misc_VirtualSize bytes belong in the mapped view.
+                if len(section_data) > virtual_size:
+                    # VirtualSize < SizeOfRawData: the extra disk bytes are
+                    # file-alignment padding the OS loader discards.
+                    section_data = section_data[:virtual_size]
+                else:
+                    # VirtualSize > SizeOfRawData: the gap is BSS and must be
+                    # zero-padded in the mapped view.
+                    section_data += b"\0" * (virtual_size - len(section_data))
+            mapped_data += section_data
 
         # If the image was rebased, restore it to its original form
         if ImageBase is not None:

--- a/pefile.py
+++ b/pefile.py
@@ -6329,14 +6329,14 @@ class PE:
             virtual_size = section.Misc_VirtualSize
             if virtual_size and len(section_data) != virtual_size:
                 # Only Misc_VirtualSize bytes belong in the mapped view.
-                if len(section_data) > virtual_size:
+                if virtual_size < len(section_data):
                     # VirtualSize < SizeOfRawData: the extra disk bytes are
                     # file-alignment padding the OS loader discards.
                     section_data = section_data[:virtual_size]
-                else:
+                elif virtual_size > len(section_data):
                     # VirtualSize > SizeOfRawData: the gap is BSS and must be
                     # zero-padded in the mapped view.
-                    section_data += b"\0" * (virtual_size - len(section_data))
+                    section_data += b"\x00" * (virtual_size - len(section_data))
             mapped_data += section_data
 
         # If the image was rebased, restore it to its original form

--- a/tests/pefile_test.py
+++ b/tests/pefile_test.py
@@ -776,7 +776,7 @@ def _create_pe(virtual_size, size_of_raw_data):
     headers = headers.ljust(pointer_to_raw_data, b"\x00")
 
     # Fill raw section data with a sentinel byte so leakage is obvious
-    section_data = b"\xcc" * size_of_raw_data
+    section_data = b"\xCC" * size_of_raw_data
     return bytes(headers) + section_data
 
 
@@ -797,7 +797,7 @@ class Test_memory_mapped_image(unittest.TestCase):
         # Section content up to VirtualSize must be present.
         self.assertEqual(
             image[va : va + vsize],
-            b"\xcc" * vsize,
+            b"\xCC" * vsize,
             "section content must be preserved up to VirtualSize",
         )
         # The image must not extend past VirtualAddress + VirtualSize; raw
@@ -811,7 +811,7 @@ class Test_memory_mapped_image(unittest.TestCase):
     def test_virtual_size_greater_than_raw_size(self):
         """Uninitialized BSS region must be zero-padded in the memory-mapped image.
 
-        When VirtualSize > SizeOfRawData the bytes from SizeOfRawData up to
+        When SizeOfRawData < VirtualSize the bytes from SizeOfRawData up to
         VirtualSize represent BSS and must be zero in the mapped view.
         """
         vsize = 0x1500
@@ -822,7 +822,7 @@ class Test_memory_mapped_image(unittest.TestCase):
         va = pe.sections[0].VirtualAddress
         self.assertEqual(
             image[va : va + raw_size],
-            b"\xcc" * raw_size,
+            b"\xCC" * raw_size,
             "raw section content must be preserved",
         )
         self.assertEqual(

--- a/tests/pefile_test.py
+++ b/tests/pefile_test.py
@@ -344,6 +344,56 @@ class TestPEFile(unittest.TestCase):
         control_file = os.path.join(REGRESSION_TESTS_DIR, "empty_file")
         self.assertRaises(pefile.PEFormatError, pefile.PE, control_file)
 
+    def test_virtual_size_less_than_raw_size(self):
+        """File-alignment padding must not bleed into the memory-mapped image.
+
+        When VirtualSize < SizeOfRawData the bytes beyond VirtualSize are
+        disk padding that the OS loader never maps.  The memory-mapped image
+        must end at VirtualAddress + VirtualSize, not VirtualAddress + SizeOfRawData.
+        """
+        vsize = 0x800
+        raw_size = 0x1000
+        pe = pefile.PE(data=_create_pe(vsize, raw_size))
+        image = pe.get_memory_mapped_image()
+
+        va = pe.sections[0].VirtualAddress
+        # Section content up to VirtualSize must be present.
+        self.assertEqual(
+            image[va : va + vsize],
+            b"\xCC" * vsize,
+            "section content must be preserved up to VirtualSize",
+        )
+        # The image must not extend past VirtualAddress + VirtualSize; raw
+        # file-padding bytes (0xCC beyond the boundary) must not be included.
+        self.assertEqual(
+            len(image),
+            va + vsize,
+            "mapped image must not include raw file-padding past VirtualSize",
+        )
+
+    def test_virtual_size_greater_than_raw_size(self):
+        """Uninitialized BSS region must be zero-padded in the memory-mapped image.
+
+        When SizeOfRawData < VirtualSize the bytes from SizeOfRawData up to
+        VirtualSize represent BSS and must be zero in the mapped view.
+        """
+        vsize = 0x1500
+        raw_size = 0x1000
+        pe = pefile.PE(data=_create_pe(vsize, raw_size))
+        image = pe.get_memory_mapped_image()
+
+        va = pe.sections[0].VirtualAddress
+        self.assertEqual(
+            image[va : va + raw_size],
+            b"\xCC" * raw_size,
+            "raw section content must be preserved",
+        )
+        self.assertEqual(
+            image[va + raw_size : va + vsize],
+            b"\x00" * (vsize - raw_size),
+            "BSS region (VirtualSize - SizeOfRawData) must be zero-padded",
+        )
+
     def test_relocated_memory_mapped_image(self):
         """Test different rebasing methods produce the same image"""
 
@@ -749,7 +799,7 @@ def _create_pe(virtual_size, size_of_raw_data):
         + struct.pack("<HHHHHH", 6, 0, 0, 0, 6, 0)  # OS/Image/Subsystem versions
         + struct.pack("<I", 0)  # Win32VersionValue
         + struct.pack("<I", size_of_image)  # SizeOfImage
-        + struct.pack("<I", pointer_to_raw_data)  # SizeOfHeaders
+        + struct.pack("<I", 0x200)  # SizeOfHeaders (headers rounded up to FileAlignment)
         + struct.pack("<I", 0)  # CheckSum
         + struct.pack("<H", 2)  # Subsystem GUI
         + struct.pack("<H", 0x8100)  # DllCharacteristics
@@ -778,55 +828,3 @@ def _create_pe(virtual_size, size_of_raw_data):
     # Fill raw section data with a sentinel byte so leakage is obvious
     section_data = b"\xCC" * size_of_raw_data
     return bytes(headers) + section_data
-
-
-class Test_memory_mapped_image(unittest.TestCase):
-    def test_virtual_size_less_than_raw_size(self):
-        """File-alignment padding must not bleed into the memory-mapped image.
-
-        When VirtualSize < SizeOfRawData the bytes beyond VirtualSize are
-        disk padding that the OS loader never maps.  The memory-mapped image
-        must end at VirtualAddress + VirtualSize, not VirtualAddress + SizeOfRawData.
-        """
-        vsize = 0x800
-        raw_size = 0x1000
-        pe = pefile.PE(data=_create_pe(vsize, raw_size))
-        image = pe.get_memory_mapped_image()
-
-        va = pe.sections[0].VirtualAddress
-        # Section content up to VirtualSize must be present.
-        self.assertEqual(
-            image[va : va + vsize],
-            b"\xCC" * vsize,
-            "section content must be preserved up to VirtualSize",
-        )
-        # The image must not extend past VirtualAddress + VirtualSize; raw
-        # file-padding bytes (0xCC beyond the boundary) must not be included.
-        self.assertEqual(
-            len(image),
-            va + vsize,
-            "mapped image must not include raw file-padding past VirtualSize",
-        )
-
-    def test_virtual_size_greater_than_raw_size(self):
-        """Uninitialized BSS region must be zero-padded in the memory-mapped image.
-
-        When SizeOfRawData < VirtualSize the bytes from SizeOfRawData up to
-        VirtualSize represent BSS and must be zero in the mapped view.
-        """
-        vsize = 0x1500
-        raw_size = 0x1000
-        pe = pefile.PE(data=_create_pe(vsize, raw_size))
-        image = pe.get_memory_mapped_image()
-
-        va = pe.sections[0].VirtualAddress
-        self.assertEqual(
-            image[va : va + raw_size],
-            b"\xCC" * raw_size,
-            "raw section content must be preserved",
-        )
-        self.assertEqual(
-            image[va + raw_size : va + vsize],
-            b"\x00" * (vsize - raw_size),
-            "BSS region (VirtualSize - SizeOfRawData) must be zero-padded",
-        )

--- a/tests/pefile_test.py
+++ b/tests/pefile_test.py
@@ -4,6 +4,7 @@ import struct
 import sys
 import unittest
 from hashlib import sha256
+import struct
 
 import pefile
 
@@ -708,3 +709,124 @@ def _low_alignment_resource_pe():
         "<8sIIIIIIHHI", b".rsrc\x00\x00\x00", len(res), va, len(res), ptr_raw, 0, 0, 0, 0, 0x40000040
     )
     return dos + b"PE\x00\x00" + coff + opt + section + res
+
+
+def _create_pe(virtual_size, size_of_raw_data):
+    """Build a minimal PE32 with one section whose VirtualSize and SizeOfRawData differ.
+
+    Reused by the memory-mapped-image tests below.
+    """
+
+    dos_header = bytearray(64)
+    dos_header[0:2] = b"MZ"
+    dos_header[60:64] = struct.pack("<I", 64)
+
+    file_header = (
+        struct.pack("<H", 0x014C)  # Machine = I386
+        + struct.pack("<H", 1)  # NumberOfSections
+        + struct.pack("<I", 0)  # TimeDateStamp
+        + struct.pack("<I", 0)  # PointerToSymbolTable
+        + struct.pack("<I", 0)  # NumberOfSymbols
+        + struct.pack("<H", 0xE0)  # SizeOfOptionalHeader
+        + struct.pack("<H", 0x0102)  # Characteristics
+    )
+
+    section_alignment = 0x1000
+    pointer_to_raw_data = 0x400  # section data starts at file offset 0x400
+    va = 0x1000  # section virtual address
+    size_of_image = va + max(virtual_size, size_of_raw_data)
+    size_of_image = (size_of_image + section_alignment - 1) & ~(section_alignment - 1)
+
+    opt_header = (
+        struct.pack("<H", 0x010B)  # Magic PE32
+        + struct.pack("<BB", 14, 0)  # LinkerVersion
+        + struct.pack("<I", size_of_raw_data)  # SizeOfCode
+        + struct.pack("<II", 0, 0)  # SizeOfInitializedData, SizeOfUninitializedData
+        + struct.pack("<I", va)  # AddressOfEntryPoint
+        + struct.pack("<II", va, 0)  # BaseOfCode, BaseOfData
+        + struct.pack("<I", 0x400000)  # ImageBase
+        + struct.pack("<II", section_alignment, 0x200)  # FileAlignment
+        + struct.pack("<HHHHHH", 6, 0, 0, 0, 6, 0)  # OS/Image/Subsystem versions
+        + struct.pack("<I", 0)  # Win32VersionValue
+        + struct.pack("<I", size_of_image)  # SizeOfImage
+        + struct.pack("<I", pointer_to_raw_data)  # SizeOfHeaders
+        + struct.pack("<I", 0)  # CheckSum
+        + struct.pack("<H", 2)  # Subsystem GUI
+        + struct.pack("<H", 0x8100)  # DllCharacteristics
+        + struct.pack("<IIII", 0x100000, 0x1000, 0x100000, 0x1000)
+        + struct.pack("<II", 0, 16)  # LoaderFlags, NumberOfRvaAndSizes
+        + b"\x00" * 128  # DataDirectory (16 entries, all zero)
+    )
+    assert len(opt_header) == 0xE0
+
+    section_header = (
+        b".text\x00\x00\x00"  # Name
+        + struct.pack("<I", virtual_size)  # VirtualSize
+        + struct.pack("<I", va)  # VirtualAddress
+        + struct.pack("<I", size_of_raw_data)  # SizeOfRawData
+        + struct.pack("<I", pointer_to_raw_data)  # PointerToRawData
+        + struct.pack("<IIHHI", 0, 0, 0, 0, 0x60000020)
+        # PointerToRelocations, PointerToLinenumbers,
+        # NumberOfRelocations, NumberOfLinenumbers, Characteristics
+    )
+
+    headers = (
+        bytes(dos_header) + b"PE\x00\x00" + file_header + opt_header + section_header
+    )
+    headers = headers.ljust(pointer_to_raw_data, b"\x00")
+
+    # Fill raw section data with a sentinel byte so leakage is obvious
+    section_data = b"\xcc" * size_of_raw_data
+    return bytes(headers) + section_data
+
+
+class Test_memory_mapped_image(unittest.TestCase):
+    def test_virtual_size_less_than_raw_size(self):
+        """File-alignment padding must not bleed into the memory-mapped image.
+
+        When VirtualSize < SizeOfRawData the bytes beyond VirtualSize are
+        disk padding that the OS loader never maps.  The memory-mapped image
+        must end at VirtualAddress + VirtualSize, not VirtualAddress + SizeOfRawData.
+        """
+        vsize = 0x800
+        raw_size = 0x1000
+        pe = pefile.PE(data=_create_pe(vsize, raw_size))
+        image = pe.get_memory_mapped_image()
+
+        va = pe.sections[0].VirtualAddress
+        # Section content up to VirtualSize must be present.
+        self.assertEqual(
+            image[va : va + vsize],
+            b"\xcc" * vsize,
+            "section content must be preserved up to VirtualSize",
+        )
+        # The image must not extend past VirtualAddress + VirtualSize; raw
+        # file-padding bytes (0xCC beyond the boundary) must not be included.
+        self.assertEqual(
+            len(image),
+            va + vsize,
+            "mapped image must not include raw file-padding past VirtualSize",
+        )
+
+    def test_virtual_size_greater_than_raw_size(self):
+        """Uninitialized BSS region must be zero-padded in the memory-mapped image.
+
+        When VirtualSize > SizeOfRawData the bytes from SizeOfRawData up to
+        VirtualSize represent BSS and must be zero in the mapped view.
+        """
+        vsize = 0x1500
+        raw_size = 0x1000
+        pe = pefile.PE(data=_create_pe(vsize, raw_size))
+        image = pe.get_memory_mapped_image()
+
+        va = pe.sections[0].VirtualAddress
+        self.assertEqual(
+            image[va : va + raw_size],
+            b"\xcc" * raw_size,
+            "raw section content must be preserved",
+        )
+        self.assertEqual(
+            image[va + raw_size : va + vsize],
+            b"\x00" * (vsize - raw_size),
+            "BSS region (VirtualSize - SizeOfRawData) must be zero-padded",
+        )


### PR DESCRIPTION
## Summary

Fixes #392.

`get_memory_mapped_image()` returned raw section data up to `SizeOfRawData`
bytes for every section, ignoring `Misc_VirtualSize`. The PE/COFF spec
(and the Windows loader) define two distinct behaviors:

| Condition | Expected mapped content |
|---|---|
| `VirtualSize < SizeOfRawData` | Only `VirtualSize` bytes are mapped; the remaining disk bytes are file-alignment padding and must **not** appear in the memory view |
| `VirtualSize > SizeOfRawData` | `SizeOfRawData` bytes are mapped, then the section is **zero-padded** to `VirtualSize` (BSS region) |

### Root cause

The single line responsible:

```python
mapped_data += section.get_data()   # always returns SizeOfRawData bytes
```

`section.get_data()` (without `ignore_padding=True`) returns exactly `SizeOfRawData`
bytes, so file-alignment padding silently bleeds into the mapped view whenever
`VirtualSize < SizeOfRawData`, and the BSS tail is truncated whenever
`VirtualSize > SizeOfRawData`.

### Fix

After fetching the raw section data, clip it to `VirtualSize` (drops disk
padding) and zero-pad it to `VirtualSize` if shorter (fills BSS):

```python
section_data = section.get_data()
if section.Misc_VirtualSize:
    if len(section_data) > section.Misc_VirtualSize:
        section_data = section_data[: section.Misc_VirtualSize]
    elif len(section_data) < section.Misc_VirtualSize:
        section_data += b"\0" * (section.Misc_VirtualSize - len(section_data))
mapped_data += section_data
```

Two regression tests covering both directions of the inequality are added to
`tests/export_test.py` using a synthetic, self-contained PE binary so they
require no external test files.

---

This pull request was prepared with the assistance of AI, under my direction and review.