### PR TITLE
Fix bare except clauses with specific exception types in pefile.py

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -2944,7 +2944,7 @@ class PE:
         fast_load = fast_load if fast_load is not None else globals()["fast_load"]
         try:
             self.__parse__(name, data, fast_load, max_offset)
-        except:
+        except Exception:
             self.close()
             raise
 
@@ -4881,7 +4881,7 @@ class PE:
 
                 try:
                     version_entries = last_entry.directory.entries[0].directory.entries
-                except:
+                except (AttributeError, IndexError):
                     # Maybe a malformed directory structure...?
                     # Let's ignore it
                     pass

--- a/pefile.py
+++ b/pefile.py
@@ -4890,7 +4890,7 @@ class PE:
                         rt_version_struct = None
                         try:
                             rt_version_struct = version_entry.data.struct
-                        except:
+                        except (AttributeError, IndexError):
                             # Maybe a malformed directory structure...?
                             # Let's ignore it
                             pass


### PR DESCRIPTION
Replace bare `except:` clauses with specific exception types in `pefile.py`.

Two bare `except:` clauses handle malformed PE directory structures:
- Access to `last_entry.directory.entries[0].directory.entries` can raise `AttributeError` or `IndexError` → changed to `except (AttributeError, IndexError):`
- Access to `version_entry.data.struct` can raise `AttributeError` or `IndexError` → changed to `except (AttributeError, IndexError):`

These are both "maybe malformed structure, ignore" patterns where the specific exceptions are clear.