### PR TITLE
Fix resource parsing for low-alignment PE images (#465)

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -1139,7 +1139,6 @@ class SectionStructure(Structure):
 
     def get_PointerToRawData_adj(self):
         if self.PointerToRawData_adj is None and self.PointerToRawData is not None:
-            ptrd = self.pe.adjust_PointerToRawData(self.PointerToRawData)
             # When the SectionAlignment is smaller than the native page-size the
             # loader reads a section's data straight from PointerToRawData without
             # rounding it down to a sector boundary (LdrpWx86FormatVirtualImage).
@@ -1149,6 +1148,8 @@ class SectionStructure(Structure):
             # resource directory RVA->offset lookup into the MZ header.
             if self.pe.OPTIONAL_HEADER.SectionAlignment < 0x1000:
                 ptrd = self.PointerToRawData
+            else:
+                ptrd = self.pe.adjust_PointerToRawData(self.PointerToRawData)
             self.PointerToRawData_adj = ptrd
         return self.PointerToRawData_adj
 

--- a/pefile.py
+++ b/pefile.py
@@ -1147,10 +1147,11 @@ class SectionStructure(Structure):
             # 0x160 / VirtualAddress 0x1a0, and rounding that down to 0 sends the
             # resource directory RVA->offset lookup into the MZ header.
             if self.pe.OPTIONAL_HEADER.SectionAlignment < 0x1000:
-                ptrd = self.PointerToRawData
+                self.PointerToRawData_adj = self.PointerToRawData
             else:
-                ptrd = self.pe.adjust_PointerToRawData(self.PointerToRawData)
-            self.PointerToRawData_adj = ptrd
+                self.PointerToRawData_adj = self.pe.adjust_PointerToRawData(
+                    self.PointerToRawData
+                )
         return self.PointerToRawData_adj
 
     def get_VirtualAddress_adj(self):

--- a/pefile.py
+++ b/pefile.py
@@ -1140,13 +1140,15 @@ class SectionStructure(Structure):
     def get_PointerToRawData_adj(self):
         if self.PointerToRawData_adj is None and self.PointerToRawData is not None:
             ptrd = self.pe.adjust_PointerToRawData(self.PointerToRawData)
-            # When the SectionAligment is smaller than the native page-size if the
-            # section’s PointerToRawData and VirtualAddress match, the section's data
-            # will be read at that offset. Implemented in the Window's function:
-            # LdrpWx86FormatVirtualImage.
+            # When the SectionAlignment is smaller than the native page-size the
+            # loader reads a section's data straight from PointerToRawData without
+            # rounding it down to a sector boundary (LdrpWx86FormatVirtualImage).
+            # This isn't limited to sections where PointerToRawData ==
+            # VirtualAddress: resource-only images can have e.g. PointerToRawData
+            # 0x160 / VirtualAddress 0x1a0, and rounding that down to 0 sends the
+            # resource directory RVA->offset lookup into the MZ header.
             if self.pe.OPTIONAL_HEADER.SectionAlignment < 0x1000:
-                if self.PointerToRawData == self.VirtualAddress:
-                    ptrd = self.VirtualAddress
+                ptrd = self.PointerToRawData
             self.PointerToRawData_adj = ptrd
         return self.PointerToRawData_adj
 

--- a/tests/pefile_test.py
+++ b/tests/pefile_test.py
@@ -10,44 +10,6 @@ import pefile
 REGRESSION_TESTS_DIR = "tests/test_files"
 
 
-def _low_alignment_resource_pe():
-    """Minimal PE32 with SectionAlignment == FileAlignment == 0x10 and a single
-    .rsrc section whose PointerToRawData (0x160) differs from its VirtualAddress
-    (0x1a0), mirroring the resource-only DLL reported in issue #465."""
-    va, ptr_raw = 0x1A0, 0x160
-
-    # resource tree, offsets relative to the start of .rsrc (RVA 0x1a0)
-    res = b""
-    res += struct.pack("<IIHHHH", 0, 0, 0, 0, 0, 1)  # type dir, one id entry
-    res += struct.pack("<II", 3, 0x80000000 | 0x18)  # type 3 -> name dir
-    res += struct.pack("<IIHHHH", 0, 0, 0, 0, 0, 1)  # name dir
-    res += struct.pack("<II", 1, 0x80000000 | 0x30)  # name 1 -> lang dir
-    res += struct.pack("<IIHHHH", 0, 0, 0, 0, 0, 1)  # lang dir
-    res += struct.pack("<II", 0x409, 0x48)           # lang -> data entry
-    res += struct.pack("<IIII", va + 0x58, 4, 0, 0)  # data entry
-    res += b"TEST"
-
-    dos = b"MZ" + b"\x00" * 0x3A + struct.pack("<I", 0x40)
-    coff = struct.pack("<HHIIIHH", 0x14C, 1, 0, 0, 0, 0xE0, 0x2102)
-    size_of_image = (va + len(res) + 0xF) & ~0xF
-    opt = struct.pack("<HBBIIIIII", 0x10B, 0, 0, 0, 0, 0, 0, 0, 0)
-    opt += struct.pack("<III", 0x400000, 0x10, 0x10)
-    opt += struct.pack("<HHHHHH", 4, 0, 0, 0, 4, 0)
-    opt += struct.pack("<I", 0)
-    opt += struct.pack("<II", size_of_image, ptr_raw)
-    opt += struct.pack("<IHH", 0, 2, 0)
-    opt += struct.pack("<IIII", 0, 0, 0, 0)
-    opt += struct.pack("<II", 0, 16)
-    dirs = [(0, 0)] * 16
-    dirs[2] = (va, len(res))  # resource directory
-    for rva, sz in dirs:
-        opt += struct.pack("<II", rva, sz)
-    section = struct.pack(
-        "<8sIIIIIIHHI", b".rsrc\x00\x00\x00", len(res), va, len(res), ptr_raw, 0, 0, 0, 0, 0x40000040
-    )
-    return dos + b"PE\x00\x00" + coff + opt + section + res
-
-
 class TestPEFile(unittest.TestCase):
     maxDiff = None
 
@@ -708,3 +670,41 @@ class TestPEFile(unittest.TestCase):
         )
         pe = pefile.PE(control_file)
         self.assertTrue(pe.verify_checksum())
+
+
+def _low_alignment_resource_pe():
+    """Minimal PE32 with SectionAlignment == FileAlignment == 0x10 and a single
+    .rsrc section whose PointerToRawData (0x160) differs from its VirtualAddress
+    (0x1a0), mirroring the resource-only DLL reported in issue #465."""
+    va, ptr_raw = 0x1A0, 0x160
+
+    # resource tree, offsets relative to the start of .rsrc (RVA 0x1a0)
+    res = b""
+    res += struct.pack("<IIHHHH", 0, 0, 0, 0, 0, 1)  # type dir, one id entry
+    res += struct.pack("<II", 3, 0x80000000 | 0x18)  # type 3 -> name dir
+    res += struct.pack("<IIHHHH", 0, 0, 0, 0, 0, 1)  # name dir
+    res += struct.pack("<II", 1, 0x80000000 | 0x30)  # name 1 -> lang dir
+    res += struct.pack("<IIHHHH", 0, 0, 0, 0, 0, 1)  # lang dir
+    res += struct.pack("<II", 0x409, 0x48)           # lang -> data entry
+    res += struct.pack("<IIII", va + 0x58, 4, 0, 0)  # data entry
+    res += b"TEST"
+
+    dos = b"MZ" + b"\x00" * 0x3A + struct.pack("<I", 0x40)
+    coff = struct.pack("<HHIIIHH", 0x14C, 1, 0, 0, 0, 0xE0, 0x2102)
+    size_of_image = (va + len(res) + 0xF) & ~0xF
+    opt = struct.pack("<HBBIIIIII", 0x10B, 0, 0, 0, 0, 0, 0, 0, 0)
+    opt += struct.pack("<III", 0x400000, 0x10, 0x10)
+    opt += struct.pack("<HHHHHH", 4, 0, 0, 0, 4, 0)
+    opt += struct.pack("<I", 0)
+    opt += struct.pack("<II", size_of_image, ptr_raw)
+    opt += struct.pack("<IHH", 0, 2, 0)
+    opt += struct.pack("<IIII", 0, 0, 0, 0)
+    opt += struct.pack("<II", 0, 16)
+    dirs = [(0, 0)] * 16
+    dirs[2] = (va, len(res))  # resource directory
+    for rva, sz in dirs:
+        opt += struct.pack("<II", rva, sz)
+    section = struct.pack(
+        "<8sIIIIIIHHI", b".rsrc\x00\x00\x00", len(res), va, len(res), ptr_raw, 0, 0, 0, 0, 0x40000040
+    )
+    return dos + b"PE\x00\x00" + coff + opt + section + res

--- a/tests/pefile_test.py
+++ b/tests/pefile_test.py
@@ -1,5 +1,6 @@
 import difflib
 import os
+import struct
 import sys
 import unittest
 from hashlib import sha256
@@ -7,6 +8,44 @@ from hashlib import sha256
 import pefile
 
 REGRESSION_TESTS_DIR = "tests/test_files"
+
+
+def _low_alignment_resource_pe():
+    """Minimal PE32 with SectionAlignment == FileAlignment == 0x10 and a single
+    .rsrc section whose PointerToRawData (0x160) differs from its VirtualAddress
+    (0x1a0), mirroring the resource-only DLL reported in issue #465."""
+    va, ptr_raw = 0x1A0, 0x160
+
+    # resource tree, offsets relative to the start of .rsrc (RVA 0x1a0)
+    res = b""
+    res += struct.pack("<IIHHHH", 0, 0, 0, 0, 0, 1)  # type dir, one id entry
+    res += struct.pack("<II", 3, 0x80000000 | 0x18)  # type 3 -> name dir
+    res += struct.pack("<IIHHHH", 0, 0, 0, 0, 0, 1)  # name dir
+    res += struct.pack("<II", 1, 0x80000000 | 0x30)  # name 1 -> lang dir
+    res += struct.pack("<IIHHHH", 0, 0, 0, 0, 0, 1)  # lang dir
+    res += struct.pack("<II", 0x409, 0x48)           # lang -> data entry
+    res += struct.pack("<IIII", va + 0x58, 4, 0, 0)  # data entry
+    res += b"TEST"
+
+    dos = b"MZ" + b"\x00" * 0x3A + struct.pack("<I", 0x40)
+    coff = struct.pack("<HHIIIHH", 0x14C, 1, 0, 0, 0, 0xE0, 0x2102)
+    size_of_image = (va + len(res) + 0xF) & ~0xF
+    opt = struct.pack("<HBBIIIIII", 0x10B, 0, 0, 0, 0, 0, 0, 0, 0)
+    opt += struct.pack("<III", 0x400000, 0x10, 0x10)
+    opt += struct.pack("<HHHHHH", 4, 0, 0, 0, 4, 0)
+    opt += struct.pack("<I", 0)
+    opt += struct.pack("<II", size_of_image, ptr_raw)
+    opt += struct.pack("<IHH", 0, 2, 0)
+    opt += struct.pack("<IIII", 0, 0, 0, 0)
+    opt += struct.pack("<II", 0, 16)
+    dirs = [(0, 0)] * 16
+    dirs[2] = (va, len(res))  # resource directory
+    for rva, sz in dirs:
+        opt += struct.pack("<II", rva, sz)
+    section = struct.pack(
+        "<8sIIIIIIHHI", b".rsrc\x00\x00\x00", len(res), va, len(res), ptr_raw, 0, 0, 0, 0, 0x40000040
+    )
+    return dos + b"PE\x00\x00" + coff + opt + section + res
 
 
 class TestPEFile(unittest.TestCase):
@@ -496,6 +535,17 @@ class TestPEFile(unittest.TestCase):
             pe.get_data(0x2000, 10),
             pe.__data__[0:10],
         )
+
+    def test_low_alignment_section_pointer_to_raw_data(self):
+        # Issue #465: for low-alignment images (SectionAlignment < 0x1000) a
+        # section's PointerToRawData must not be rounded down to a sector
+        # boundary. Resource-only DLLs can have e.g. PointerToRawData 0x160 with
+        # VirtualAddress 0x1a0; rounding 0x160 down to 0 sent RVA->offset lookups
+        # into the MZ header, so the resource directory failed to parse.
+        pe = pefile.PE(data=_low_alignment_resource_pe())
+        self.assertEqual(pe.get_offset_from_rva(0x1A0), 0x160)
+        self.assertTrue(hasattr(pe, "DIRECTORY_ENTRY_RESOURCE"))
+        self.assertEqual([e.id for e in pe.DIRECTORY_ENTRY_RESOURCE.entries], [3])
 
     def test_VS_VERSIONINFO_dword_aligment(self):
         # Fixed a bug in pefile < 1.2.10-96. Fixed in revision 96:


### PR DESCRIPTION
## What

Fixes #465: resources in resource-only PE files (and other low-alignment images) don't parse.

## Why

The sample in the issue is a single-section `.rsrc` DLL with `SectionAlignment == FileAlignment == 0x10`, `PointerToRawData = 0x160`, `VirtualAddress = 0x1a0`.

For low-alignment images (SectionAlignment < the page size) the loader reads a section's data straight from `PointerToRawData` without rounding it down to a 0x200 sector boundary. `SectionStructure.get_PointerToRawData_adj` only accounted for that when `PointerToRawData == VirtualAddress`. Here they differ, so `adjust_PointerToRawData(0x160)` rounded the pointer down to `0`. `get_offset_from_rva(0x1a0)` then resolved to `0` (the MZ header) instead of `0x160`, the resource directory was read from the wrong place, and parsing bailed with:

```
Error parsing the resources directory. The directory contains 65535 entries (>4096)
```

so `DIRECTORY_ENTRY_RESOURCE` was never populated.

## Fix

Use the unrounded `PointerToRawData` for all sections in a low-alignment image, not only when it equals `VirtualAddress` (that case is subsumed). One-line change in `get_PointerToRawData_adj`.

With the fix, the issue's sample resolves `get_offset_from_rva(0x1a0) == 0x160` and its resources parse.

## Testing

- Added `test_low_alignment_section_pointer_to_raw_data`, which builds a minimal low-alignment PE with a resource tree in-memory (no test-corpus file needed). It fails before this change (RVA→offset resolves to 0, no resource types) and passes after.
- Ran the full `erocarrera/pefile-tests` regression suite (748 files) against the change: **no output differences** and no new load failures. Of the 35 low-alignment files in that corpus, none change (their raw pointers are already sector-aligned or equal to `VirtualAddress`), so no `.dmp` fixtures need regenerating.
- `flake8 --select=E9,F63,F7,F82` clean.

Note: I placed the test in `tests/pefile_test.py` alongside the other alignment/`PointerToRawData` tests. Since the tox run currently `--ignore`s that file, happy to port the test to `erocarrera/pefile-tests` instead if you'd prefer it run in CI.
