### PR TITLE
Refactor set_format

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -29,7 +29,7 @@ import string
 import struct
 import time
 import uuid
-from collections import Counter, defaultdict
+from collections import Counter, namedtuple, defaultdict
 from functools import lru_cache, wraps
 from hashlib import md5, sha1, sha256, sha512
 
@@ -919,12 +919,9 @@ def set_format(format):
 
     __format_length__ = struct.calcsize(__format_str__)
 
-    return (
-        __format_str__,
-        __format_length__,
-        __field_offsets__,
-        __keys__,
-    )
+    Format = namedtuple('Format', '__format_str__, __format_length__, __field_offsets__, __keys__')
+
+    return Format(__format_str__, __format_length__, __field_offsets__, __keys__)
 
 
 class Structure:

--- a/pefile.py
+++ b/pefile.py
@@ -889,7 +889,6 @@ def sizeof_type(t):
 @lru_cache_copy(maxsize=2048)
 def set_format(format):
     __format_str__ = "<"
-    __unpacked_data_elms__ = []
     __field_offsets__ = {}
     __keys__ = []
     __format_length__ = 0
@@ -899,7 +898,6 @@ def set_format(format):
         if "," in elm:
             elm_type, elm_name = elm.split(",", 1)
             __format_str__ += elm_type
-            __unpacked_data_elms__.append(None)
 
             elm_names = elm_name.split(",")
             names = []
@@ -922,7 +920,6 @@ def set_format(format):
 
     return (
         __format_str__,
-        __unpacked_data_elms__,
         __field_offsets__,
         __keys__,
         __format_length__,
@@ -939,29 +936,29 @@ class Structure:
     def __init__(self, format, name=None, file_offset=None):
         # Format is forced little endian, for big endian non-Intel platforms
         self.__format_str__ = "<"
-        self.__unpacked_data_elms__ = []
         self.__field_offsets__ = {}
         self.__keys__ = []
         self.__format_length__ = 0
-
-        d = format[1]
-        # need a tuple to be hashable in set_format using lru cache
-        if not isinstance(d, tuple):
-            d = tuple(d)
-
-        (
-            self.__format_str__,
-            self.__unpacked_data_elms__,
-            self.__field_offsets__,
-            self.__keys__,
-            self.__format_length__,
-        ) = set_format(d)
 
         if name:
             self.name = name
         else:
             self.name = format[0]
+        d = format[1]
+
+        # Need a tuple to be hashable in set_format using lru cache
+        if not isinstance(d, tuple):
+            d = tuple(d)
+
+        (
+            self.__format_str__,
+            self.__field_offsets__,
+            self.__keys__,
+            self.__format_length__,
+        ) = set_format(d)
+
         self.__file_offset__ = file_offset
+        self.__unpacked_data_elms__ = [None] * self.__keys__
         self.__all_zeroes__ = False
 
     def __get_format__(self) -> str:

--- a/pefile.py
+++ b/pefile.py
@@ -889,39 +889,39 @@ def sizeof_type(t):
 @lru_cache_copy(maxsize=2048)
 def set_format(format):
     # Format is forced little endian, for big endian non-Intel platforms
-    __format_str__ = "<"
-    __format_length__ = 0
-    __field_offsets__ = {}
-    __keys__ = []
+    format_str = "<"
+    format_length = 0
+    field_offsets = {}
+    keys = []
 
     offset = 0
     for elm in format:
         if "," in elm:
             elm_type, elm_name = elm.split(",", 1)
-            __format_str__ += elm_type
+            format_str += elm_type
 
             elm_names = elm_name.split(",")
             names = []
             for elm_name in elm_names:
-                if elm_name in __keys__:
-                    search_list = [x[: len(elm_name)] for x in __keys__]
+                if elm_name in keys:
+                    search_list = [x[: len(elm_name)] for x in keys]
                     occ_count = search_list.count(elm_name)
                     elm_name = "{0}_{1:d}".format(elm_name, occ_count)
                 names.append(elm_name)
-                __field_offsets__[elm_name] = offset
+                field_offsets[elm_name] = offset
 
             offset += sizeof_type(elm_type)
 
             # Some PE header structures have unions on them, so a certain
             # value might have different names, so each key has a list of
             # all the possible members referring to the data.
-            __keys__.append(names)
+            keys.append(names)
 
-    __format_length__ = struct.calcsize(__format_str__)
+    format_length = struct.calcsize(format_str)
 
-    Format = namedtuple('Format', '__format_str__, __format_length__, __field_offsets__, __keys__')
+    Format = namedtuple('Format', 'format_str, format_length, field_offsets, keys')
 
-    return Format(__format_str__, __format_length__, __field_offsets__, __keys__)
+    return Format(format_str, format_length, field_offsets, keys)
 
 
 class Structure:

--- a/pefile.py
+++ b/pefile.py
@@ -888,6 +888,7 @@ def sizeof_type(t):
 
 @lru_cache_copy(maxsize=2048)
 def set_format(format):
+    # Format is forced little endian, for big endian non-Intel platforms
     __format_str__ = "<"
     __field_offsets__ = {}
     __keys__ = []
@@ -934,12 +935,6 @@ class Structure:
     """
 
     def __init__(self, format, name=None, file_offset=None):
-        # Format is forced little endian, for big endian non-Intel platforms
-        self.__format_str__ = "<"
-        self.__field_offsets__ = {}
-        self.__keys__ = []
-        self.__format_length__ = 0
-
         if name:
             self.name = name
         else:

--- a/pefile.py
+++ b/pefile.py
@@ -958,7 +958,7 @@ class Structure:
         ) = set_format(d)
 
         self.__file_offset__ = file_offset
-        self.__unpacked_data_elms__ = [None] * self.__keys__
+        self.__unpacked_data_elms__ = [None] * len(self.__keys__)
         self.__all_zeroes__ = False
 
     def __get_format__(self) -> str:

--- a/pefile.py
+++ b/pefile.py
@@ -1379,7 +1379,7 @@ def set_bitfields_format(format):
         ac.add_subfield(elm_name, elm_bits)
     ac.wrap_up()
 
-    format_str, _, field_offsets, keys, format_length = set_format(tuple(old_fmt))
+    format_str, field_offsets, keys, format_length = set_format(tuple(old_fmt))
 
     extended_keys = []
     for idx, val in enumerate(keys):

--- a/pefile.py
+++ b/pefile.py
@@ -890,9 +890,9 @@ def sizeof_type(t):
 def set_format(format):
     # Format is forced little endian, for big endian non-Intel platforms
     __format_str__ = "<"
+    __format_length__ = 0
     __field_offsets__ = {}
     __keys__ = []
-    __format_length__ = 0
 
     offset = 0
     for elm in format:
@@ -921,9 +921,9 @@ def set_format(format):
 
     return (
         __format_str__,
+        __format_length__,
         __field_offsets__,
         __keys__,
-        __format_length__,
     )
 
 
@@ -947,9 +947,9 @@ class Structure:
 
         (
             self.__format_str__,
+            self.__format_length__,
             self.__field_offsets__,
             self.__keys__,
-            self.__format_length__,
         ) = set_format(d)
 
         self.__file_offset__ = file_offset
@@ -1374,7 +1374,7 @@ def set_bitfields_format(format):
         ac.add_subfield(elm_name, elm_bits)
     ac.wrap_up()
 
-    format_str, field_offsets, keys, format_length = set_format(tuple(old_fmt))
+    format_str, format_length, field_offsets, keys = set_format(tuple(old_fmt))
 
     extended_keys = []
     for idx, val in enumerate(keys):


### PR DESCRIPTION
Because it is data, not formatting information, `__unpacked_data_elms__ ` is not a good fit for set_format. It is also redundant, and can be created from other return values of the function.