### PR TITLE
Use the Ruff Linter to fix any fixable errors

### DIFF
--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -115,7 +115,7 @@ class TestExports(unittest.TestCase):
         self.assertEqual(EXPECT_NAMES, exports)
 
 
-"""
+r"""
 To generate the embedded files, run from a VS command prompt:
 link /NOLOGO /SUBSYSTEM:WINDOWS /NOIMPLIB /NOEXP /ALIGN:0x10 /DEF:test.def /DLL /NOENTRY /MACHINE:X86 /OUT:test32.dll
 link /NOLOGO /SUBSYSTEM:WINDOWS /NOIMPLIB /NOEXP /ALIGN:0x10 /DEF:test.def /DLL /NOENTRY /MACHINE:X64 /OUT:test64.dll

--- a/tests/pefile_test.py
+++ b/tests/pefile_test.py
@@ -4,7 +4,6 @@ import struct
 import sys
 import unittest
 from hashlib import sha256
-import struct
 
 import pefile
 
@@ -136,7 +135,7 @@ class TestPEFile(unittest.TestCase):
                     error_diff_f = open("error_diff.txt", "ab")
                     error_diff_f.write(b"\n________________________________________\n")
                     error_diff_f.write(
-                        'Errors for file "{0}":\n'.format(pe_filename).encode(
+                        f'Errors for file "{pe_filename}":\n'.encode(
                             "utf-8", "backslashreplace"
                         )
                     )


### PR DESCRIPTION
Three fixes applied to the tests folder.
F811: redefined-while-unused.
UP032: f-string.
W605: invalid-escape-sequence.